### PR TITLE
Add session browsing with SessionListScreen

### DIFF
--- a/lib/core/models/session.dart
+++ b/lib/core/models/session.dart
@@ -1,0 +1,44 @@
+/// Session model for Hermes dashboard sessions.
+class Session {
+  final String id;
+  final String title;
+  final String model;
+  final int messageCount;
+  final bool isActive;
+  final String preview;
+  final String createdAt;
+
+  const Session({
+    required this.id,
+    required this.title,
+    required this.model,
+    required this.messageCount,
+    required this.isActive,
+    required this.preview,
+    required this.createdAt,
+  });
+
+  factory Session.fromJson(Map<String, dynamic> json) {
+    return Session(
+      id: json['id'] ?? '',
+      title: json['title'] ?? 'Untitled',
+      model: json['model'] ?? 'Default',
+      messageCount: json['message_count'] ?? 0,
+      isActive: json['is_active'] ?? false,
+      preview: json['preview'] ?? 'Tap to view session...',
+      createdAt: json['created_at'] ?? '',
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'title': title,
+      'model': model,
+      'message_count': messageCount,
+      'is_active': isActive,
+      'preview': preview,
+      'created_at': createdAt,
+    };
+  }
+}

--- a/lib/core/screens/session_list_screen.dart
+++ b/lib/core/screens/session_list_screen.dart
@@ -1,0 +1,173 @@
+/// Session list screen that displays sessions from a connected Hermes dashboard.
+import 'package:flutter/material.dart';
+import '../services/connection_manager.dart';
+
+class SessionListScreen extends StatefulWidget {
+  final SavedConnection connection;
+  const SessionListScreen({required this.connection, super.key});
+
+  @override
+  State<SessionListScreen> createState() => _SessionListScreenState();
+}
+
+class _SessionListScreenState extends State<SessionListScreen> {
+  List<Session> _sessions = [];
+  bool _loading = true;
+  String? _error;
+  ApiClient? _client;
+
+  @override
+  void initState() {
+    super.initState();
+    _client = ApiClient();
+    _fetchSessions();
+  }
+
+  @override
+  void dispose() {
+    _client?.close();
+    super.dispose();
+  }
+
+  Future<void> _fetchSessions() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    try {
+      final sessions = await _client!.getSessions(widget.connection.baseUrl);
+      setState(() {
+        _sessions = sessions;
+        _loading = false;
+      });
+    } catch (e) {
+      setState(() {
+        _error = e.toString();
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.connection.label),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: _loading ? null : _fetchSessions,
+          ),
+        ],
+      ),
+      body: _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.error_outline, size: 48, color: Colors.orange),
+            const SizedBox(height: 16),
+            Text(
+              'Connection issue',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 8),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 32),
+              child: Text(
+                _error!,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: _fetchSessions,
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (_sessions.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.chat_bubble_outline, size: 48, color: Colors.grey),
+            const SizedBox(height: 16),
+            Text(
+              'No sessions yet',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Sessions will appear here when you start chatting',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _fetchSessions,
+      child: ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: _sessions.length,
+        itemBuilder: (context, index) {
+          final session = _sessions[index];
+          return Card(
+            margin: const EdgeInsets.only(bottom: 8),
+            child: ListTile(
+              leading: Icon(
+                Icons.chat,
+                color: session.isActive
+                    ? Colors.blueAccent
+                    : Colors.grey,
+              ),
+              title: Text(session.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+              subtitle: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '${session.messageCount} messages • ${session.model}',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                  if (session.preview.isNotEmpty && session.preview != 'Tap to view session...')
+                    Text(
+                      session.preview,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.grey[500]),
+                    ),
+                ],
+              ),
+              isThreeLine: session.preview.isNotEmpty && session.preview != 'Tap to view session...',
+              trailing: session.isActive
+                  ? Chip(
+                      label: const Text('Active'),
+                      backgroundColor: Colors.blueAccent,
+                      side: BorderSide.none,
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                    )
+                  : null,
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/core/services/connection_manager.dart
+++ b/lib/core/services/connection_manager.dart
@@ -3,9 +3,11 @@ import 'package:uuid/uuid.dart';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../models/connection.dart';
+import '../models/session.dart';
 
 // Re-export for convenience
 export '../models/connection.dart';
+export '../models/session.dart';
 
 /// Manages saved remote connections using SharedPreferences.
 class ConnectionManager {
@@ -64,10 +66,10 @@ class ApiClient {
     return jsonDecode(res.body) as Map<String, dynamic>;
   }
 
-  Future<List<String>> getSessionIds(String baseUrl) async {
+  Future<List<Session>> getSessions(String baseUrl) async {
     final data = await _get(baseUrl, 'sessions');
     final list = data['sessions'] as List? ?? [];
-    return list.map((s) => s.toString()).toList();
+    return list.map((s) => Session.fromJson(s as Map<String, dynamic>)).toList();
   }
 
   Future<List<Map<String, dynamic>>> getMessages(String baseUrl, String sessionId) async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'core/services/connection_manager.dart';
+import 'core/screens/session_list_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -104,7 +105,7 @@ class _HomeScreenState extends State<HomeScreen> {
                       Navigator.push(
                         context,
                         MaterialPageRoute(
-                          builder: (_) => PlaceholderScreen(title: conn.label, baseUrl: conn.baseUrl),
+                          builder: (_) => SessionListScreen(connection: conn),
                         ),
                       );
                     },
@@ -117,20 +118,6 @@ class _HomeScreenState extends State<HomeScreen> {
         onPressed: _showAddDialog,
         child: const Icon(Icons.add, color: Colors.white),
       ),
-    );
-  }
-}
-
-class PlaceholderScreen extends StatelessWidget {
-  final String title;
-  final String baseUrl;
-  const PlaceholderScreen({required this.title, required this.baseUrl, super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: Text(title)),
-      body: Center(child: Text('Sessions for $title\n$baseUrl\n\nComing soon...')),
     );
   }
 }


### PR DESCRIPTION
## Changes

- Add Session model (lib/core/models/session.dart)
- Update ApiClient to fetch Session[] from /api/sessions
- Build SessionListScreen with loading/error/empty states
- Wire session list into connection navigation