### PR TITLE
chore: bump version to 0.0.3+3 for release

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hermes_android
 description: "Hermes Agent — Multi-Session Chat via REST API"
 publish_to: 'none'
-version: 0.0.2+2
+version: 0.0.3+3
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
Closes #6

Bump version for v0.0.3 release with chat screen and Markdown rendering.