### PR TITLE
feat: Add Settings screen with Model Selection

### DIFF
--- a/lib/core/screens/session_list_screen.dart
+++ b/lib/core/screens/session_list_screen.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import '../services/connection_manager.dart';
 import 'chat_screen.dart';
+import 'settings_screen.dart';
 
 class SessionListScreen extends StatefulWidget {
   final SavedConnection connection;
@@ -56,6 +57,18 @@ class _SessionListScreenState extends State<SessionListScreen> {
       appBar: AppBar(
         title: Text(widget.connection.label),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => SettingsScreen(connection: widget.connection),
+                ),
+              );
+            },
+            tooltip: 'Settings',
+          ),
           IconButton(
             icon: const Icon(Icons.refresh),
             onPressed: _loading ? null : _fetchSessions,

--- a/lib/core/screens/settings_screen.dart
+++ b/lib/core/screens/settings_screen.dart
@@ -1,0 +1,379 @@
+/// Settings screen for model selection, theme toggle, and app info.
+import 'package:flutter/material.dart';
+import '../services/connection_manager.dart';
+
+class SettingsScreen extends StatefulWidget {
+  final SavedConnection connection;
+  const SettingsScreen({required this.connection, super.key});
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  late ApiClient _client;
+  Map<String, dynamic>? _modelInfo;
+  Map<String, dynamic>? _modelOptions;
+  bool _loading = true;
+  String? _error;
+  String? _successMsg;
+
+  // Selected values
+  String _selectedProvider = '';
+  String _selectedModel = '';
+  List<String> _providers = [];
+  Map<String, List<Map<String, dynamic>>> _providerModels = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _client = ApiClient();
+    _loadData();
+  }
+
+  @override
+  void dispose() {
+    _client.close();
+    super.dispose();
+  }
+
+  Future<void> _loadData() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    try {
+      final baseUrl = widget.connection.baseUrl;
+      final results = await Future.wait([
+        _client.getModelInfo(baseUrl),
+        _client.getModelOptions(baseUrl),
+      ]);
+
+      setState(() {
+        _modelInfo = results[0] as Map<String, dynamic>;
+        _modelOptions = results[1] as Map<String, dynamic>;
+        _loading = false;
+        _parseModelOptions();
+      });
+    } catch (e) {
+      setState(() {
+        _error = e.toString();
+        _loading = false;
+      });
+    }
+  }
+
+  void _parseModelOptions() {
+    if (_modelOptions == null) return;
+
+    final providers = _modelOptions!['providers'] as List<dynamic>? ?? [];
+    _providers = [];
+    _providerModels = {};
+
+    for (final p in providers) {
+      final pMap = p as Map<String, dynamic>;
+      final providerId = pMap['id'] as String? ?? '';
+      final models = (pMap['models'] as List<dynamic>?)
+              ?.map((m) => m as Map<String, dynamic>)
+              .toList() ??
+          [];
+      if (providerId.isNotEmpty && models.isNotEmpty) {
+        _providers.add(providerId);
+        _providerModels[providerId] = models;
+      }
+    }
+
+    // Set initial selections from current model
+    if (_modelInfo != null) {
+      _selectedProvider = (_modelInfo!['provider'] as String?) ?? '';
+      _selectedModel = (_modelInfo!['model'] as String?) ?? '';
+    }
+  }
+
+  Future<void> _applyModel() async {
+    if (_selectedProvider.isEmpty || _selectedModel.isEmpty) return;
+
+    setState(() {
+      _error = null;
+      _successMsg = null;
+    });
+
+    try {
+      await _client.setModel(
+        widget.connection.baseUrl,
+        _selectedProvider,
+        _selectedModel,
+      );
+      setState(() {
+        _successMsg = 'Model set to $_selectedModel — applies to new sessions';
+      });
+    } catch (e) {
+      setState(() {
+        _error = e.toString();
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Settings'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: _loading ? null : _loadData,
+            tooltip: 'Refresh',
+          ),
+        ],
+      ),
+      body: _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_error != null && _modelOptions == null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.error_outline, size: 48, color: Colors.orange),
+              const SizedBox(height: 16),
+              Text('Failed to load settings',
+                  style: Theme.of(context).textTheme.titleMedium),
+              const SizedBox(height: 8),
+              Text(_error!, style: Theme.of(context).textTheme.bodySmall,
+                  textAlign: TextAlign.center),
+              const SizedBox(height: 24),
+              ElevatedButton(onPressed: _loadData, child: const Text('Retry')),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        // ---- Section: Model ----
+        _buildSectionHeader('Model Selection'),
+        if (_modelInfo != null)
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(children: [
+                    Icon(Icons.smart_toy, color: Theme.of(context).colorScheme.primary),
+                    const SizedBox(width: 8),
+                    Text('Current Model',
+                        style: Theme.of(context).textTheme.titleSmall),
+                  ]),
+                  const SizedBox(height: 8),
+                  Text(
+                    '${_modelInfo!['model'] ?? '???'}  \nvia `${_modelInfo!['provider'] ?? '???'}`',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                  if (_modelInfo!['effective_context_length'] != null &&
+                      _modelInfo!['effective_context_length'] != 0)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Text(
+                        'Context: ${_modelInfo!['effective_context_length']} tokens',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.grey),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+        const SizedBox(height: 12),
+
+        // Provider picker
+        if (_providers.isNotEmpty) ...[
+          _buildDropdown<String>(
+            label: 'Provider',
+            value: _selectedProvider.isNotEmpty &&
+                    _providers.contains(_selectedProvider)
+                ? _selectedProvider
+                : null,
+            items: _providers.map((p) => DropdownMenuItem(value: p, child: Text(p))).toList(),
+            onChanged: (val) {
+              setState(() {
+                _selectedProvider = val!;
+                // Reset model when switching providers
+                final models = _providerModels[val];
+                if (models != null && models.isNotEmpty) {
+                  _selectedModel = models.first['id'] as String? ?? '';
+                } else {
+                  _selectedModel = '';
+                }
+              });
+            },
+          ),
+          const SizedBox(height: 12),
+        ],
+
+        // Model picker
+        if (_selectedProvider.isNotEmpty &&
+            _providerModels.containsKey(_selectedProvider)) ...[
+          _buildDropdown<String>(
+            label: 'Model',
+            value: _selectedModel,
+            items: _providerModels[_selectedProvider]!
+                .map((m) {
+                  final id = m['id'] as String? ?? '';
+                  final name = m['name'] as String? ?? id;
+                  return DropdownMenuItem(value: id, child: Text(name));
+                })
+                .toList(),
+            onChanged: (val) {
+              setState(() => _selectedModel = val!);
+            },
+          ),
+          const SizedBox(height: 16),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton.icon(
+              onPressed: _applyModel,
+              icon: const Icon(Icons.check),
+              label: const Text('Apply Model'),
+            ),
+          ),
+        ],
+        const SizedBox(height: 16),
+
+        // Success/error messages
+        if (_successMsg != null)
+          Card(
+            color: Colors.green.shade900,
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Text(_successMsg!,
+                  style: const TextStyle(color: Colors.white)),
+            ),
+          ),
+        if (_error != null && _modelOptions != null)
+          Card(
+            color: Colors.red.shade900,
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Text(_error!,
+                  style: const TextStyle(color: Colors.white)),
+            ),
+          ),
+
+        const SizedBox(height: 16),
+
+        // ---- Section: Theme ----
+        _buildSectionHeader('Appearance'),
+        SwitchListTile(
+          title: const Text('Dark Mode'),
+          subtitle: const Text('Follow system theme'),
+          value: Theme.of(context).brightness == Brightness.dark,
+          onChanged: (_) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Dark mode follows system setting')),
+            );
+          },
+        ),
+        const SizedBox(height: 16),
+
+        // ---- Section: Connection ----
+        _buildSectionHeader('Connection'),
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _infoRow('Label', widget.connection.label),
+                const SizedBox(height: 4),
+                _infoRow('Host', widget.connection.host),
+                const SizedBox(height: 4),
+                _infoRow('Port', '${widget.connection.port}'),
+                const SizedBox(height: 4),
+                _infoRow('Base URL', widget.connection.baseUrl),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+
+        // ---- Section: About ----
+        _buildSectionHeader('About'),
+        const Card(
+          child: Padding(
+            padding: EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Hermes Agent for Android',
+                    style: TextStyle(fontWeight: FontWeight.bold)),
+                SizedBox(height: 4),
+                Text('Version 0.0.3'),
+                SizedBox(height: 8),
+                Text(
+                  'Browse and manage your Hermes Agent sessions from your phone. '
+                  'Connects to a Hermes dashboard running on your local network.',
+                  style: TextStyle(color: Colors.grey),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSectionHeader(String title) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Text(title,
+          style: Theme.of(context)
+              .textTheme
+              .titleSmall
+              ?.copyWith(color: Theme.of(context).colorScheme.primary)),
+    );
+  }
+
+  Widget _infoRow(String label, String value) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 80,
+          child: Text(label,
+              style: const TextStyle(
+                  fontWeight: FontWeight.w500, color: Colors.grey)),
+        ),
+        Expanded(child: Text(value, overflow: TextOverflow.ellipsis)),
+      ],
+    );
+  }
+
+  Widget _buildDropdown<T>({
+    required String label,
+    required T? value,
+    required List<DropdownMenuItem<T>> items,
+    required ValueChanged<T?> onChanged,
+  }) {
+    return DropdownButtonFormField<T>(
+      value: value,
+      decoration: InputDecoration(
+        labelText: label,
+        border: const OutlineInputBorder(),
+        contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      ),
+      items: items,
+      onChanged: onChanged,
+    );
+  }
+}

--- a/lib/core/services/connection_manager.dart
+++ b/lib/core/services/connection_manager.dart
@@ -122,5 +122,64 @@ class ApiClient {
     return list.cast<Map<String, dynamic>>();
   }
 
+  Future<Map<String, dynamic>> getModelInfo(String baseUrl) async {
+    return await _get(baseUrl, 'model/info');
+  }
+
+  Future<Map<String, dynamic>> getModelOptions(String baseUrl) async {
+    return await _get(baseUrl, 'model/options');
+  }
+
+  Future<Map<String, dynamic>> setModel(String baseUrl, String provider, String model,
+      {String scope = 'main', String task = ''}) async {
+    return await _post(baseUrl, 'model/set', {
+      'scope': scope,
+      'provider': provider,
+      'model': model,
+      'task': task,
+    });
+  }
+
+  Future<Map<String, dynamic>> getConfig(String baseUrl) async {
+    return await _get(baseUrl, 'config');
+  }
+
+  Future<Map<String, dynamic>> getSkills(String baseUrl) async {
+    return await _get(baseUrl, 'skills');
+  }
+
+  Future<Map<String, dynamic>> _post(String baseUrl, String endpoint, Map<String, dynamic> body) async {
+    final token = await _getSessionToken(baseUrl);
+    final url = '$baseUrl/api/$endpoint';
+    final res = await _http.post(
+      Uri.parse(url),
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Hermes-Session-Token': token,
+      },
+      body: jsonEncode(body),
+    );
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      if (res.statusCode == 401) {
+        _tokenCache.remove(baseUrl);
+        final newToken = await _getSessionToken(baseUrl);
+        final retryRes = await _http.post(
+          Uri.parse(url),
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Hermes-Session-Token': newToken,
+          },
+          body: jsonEncode(body),
+        );
+        if (retryRes.statusCode < 200 || retryRes.statusCode >= 300) {
+          throw Exception('HTTP ${retryRes.statusCode}: ${retryRes.body}');
+        }
+        return jsonDecode(retryRes.body) as Map<String, dynamic>;
+      }
+      throw Exception('HTTP ${res.statusCode}: ${res.body}');
+    }
+    return jsonDecode(res.body) as Map<String, dynamic>;
+  }
+
   void close() => _http.close();
 }


### PR DESCRIPTION
## Summary
Adds a Settings screen accessible from the session list via a gear icon in the AppBar.

## Features
- **Model Selection**: View current model, browse providers/models, and switch models via dropdown
- **API Integration**: Uses GET /api/model/info, GET /api/model/options, and POST /api/model/set
- **Connection Info**: Display label, host, port, and base URL
- **Appearance**: Dark mode toggle (follows system)
- **About**: App version and description

## Changes
- New lib/core/screens/settings_screen.dart
- Extended ApiClient with model/config/skills methods and POST support
- Added settings navigation button to session list AppBar

Closes #9