### PR TITLE
feat: Add session search with FTS5 via dashboard API

### DIFF
--- a/lib/core/screens/session_list_screen.dart
+++ b/lib/core/screens/session_list_screen.dart
@@ -1,4 +1,5 @@
 /// Session list screen that displays sessions from a connected Hermes dashboard.
+/// Supports browse mode (all sessions) and search mode (FTS5-powered).
 import 'package:flutter/material.dart';
 import '../services/connection_manager.dart';
 import 'chat_screen.dart';
@@ -18,6 +19,13 @@ class _SessionListScreenState extends State<SessionListScreen> {
   String? _error;
   ApiClient? _client;
 
+  // Search state
+  bool _searching = false;
+  final _searchController = TextEditingController();
+  List<Map<String, dynamic>> _searchResults = [];
+  bool _searchLoading = false;
+  String? _searchError;
+
   @override
   void initState() {
     super.initState();
@@ -28,6 +36,7 @@ class _SessionListScreenState extends State<SessionListScreen> {
   @override
   void dispose() {
     _client?.close();
+    _searchController.dispose();
     super.dispose();
   }
 
@@ -51,35 +60,261 @@ class _SessionListScreenState extends State<SessionListScreen> {
     }
   }
 
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(widget.connection.label),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.settings),
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => SettingsScreen(connection: widget.connection),
-                ),
-              );
-            },
-            tooltip: 'Settings',
-          ),
-          IconButton(
-            icon: const Icon(Icons.refresh),
-            onPressed: _loading ? null : _fetchSessions,
-          ),
-        ],
+  Future<void> _doSearch(String query) async {
+    if (query.trim().isEmpty) {
+      setState(() {
+        _searchResults = [];
+        _searchError = null;
+      });
+      return;
+    }
+
+    setState(() {
+      _searchLoading = true;
+      _searchError = null;
+    });
+
+    try {
+      final data = await _client!.searchSessions(
+        widget.connection.baseUrl,
+        query.trim(),
+      );
+      setState(() {
+        _searchResults =
+            (data['results'] as List?)?.cast<Map<String, dynamic>>() ?? [];
+        _searchLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        _searchError = e.toString();
+        _searchLoading = false;
+      });
+    }
+  }
+
+  void _onSearchResultTap(Map<String, dynamic> result) {
+    final sessionId = result['session_id'] as String? ?? '';
+    if (sessionId.isEmpty) return;
+
+    // Construct a minimal session to pass to ChatScreen.
+    // The source/model/session_started fields come from the search result.
+    // We don't have message count or preview from search, so use the available fields.
+    final session = Session(
+      id: sessionId,
+      title: _bestSnippet(result['snippet'] as String?, 40),
+      model: (result['model'] as String?) ?? '',
+      messageCount: 0,
+      isActive: false,
+      preview: result['snippet'] as String? ?? '',
+      createdAt: (result['session_started'] as String?) ?? '',
+    );
+
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => ChatScreen(
+          connection: widget.connection,
+          session: session,
+        ),
       ),
-      body: _buildBody(),
     );
   }
 
-  Widget _buildBody() {
+  /// Shorten a snippet to at most `maxLen` characters, on a word boundary.
+  /// Strips Markdown formatting and leading role prefixes.
+  static String _bestSnippet(String? raw, int maxLen) {
+    if (raw == null || raw.isEmpty) return 'Untitled';
+    // Remove FTS5 highlight markers
+    var clean = raw.replaceAll(RegExp(r'<b>|</b>'), '');
+    // Strip common role prefixes
+    clean = clean.replaceFirst(
+      RegExp(r'^(user|assistant|system|tool)\s*[:：]\s*', caseSensitive: false),
+      '',
+    ).trim();
+    if (clean.length <= maxLen) return clean;
+    final truncated = clean.substring(0, maxLen);
+    final lastSpace = truncated.lastIndexOf(' ');
+    return (lastSpace > 0 ? truncated.substring(0, lastSpace) : truncated) +
+        '…';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: _searching ? _searchAppBar() : _normalAppBar(),
+      body: _searching ? _searchBody() : _browseBody(),
+    );
+  }
+
+  AppBar _normalAppBar() {
+    return AppBar(
+      title: Text(widget.connection.label),
+      actions: [
+        IconButton(
+          icon: const Icon(Icons.search),
+          onPressed: () => setState(() => _searching = true),
+          tooltip: 'Search sessions',
+        ),
+        IconButton(
+          icon: const Icon(Icons.settings),
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => SettingsScreen(connection: widget.connection),
+              ),
+            );
+          },
+          tooltip: 'Settings',
+        ),
+        IconButton(
+          icon: const Icon(Icons.refresh),
+          onPressed: _loading ? null : _fetchSessions,
+        ),
+      ],
+    );
+  }
+
+  AppBar _searchAppBar() {
+    return AppBar(
+      title: TextField(
+        controller: _searchController,
+        autofocus: true,
+        style: const TextStyle(color: Colors.white),
+        cursorColor: Colors.white,
+        decoration: const InputDecoration(
+          hintText: 'Search sessions…',
+          hintStyle: TextStyle(color: Colors.white54),
+          border: InputBorder.none,
+        ),
+        onChanged: _doSearch,
+      ),
+      actions: [
+        IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: () {
+            setState(() {
+              _searching = false;
+              _searchController.clear();
+              _searchResults = [];
+              _searchError = null;
+            });
+          },
+          tooltip: 'Close search',
+        ),
+      ],
+    );
+  }
+
+  Widget _searchBody() {
+    if (_searchLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_searchError != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.search_off, size: 48, color: Colors.grey),
+              const SizedBox(height: 16),
+              Text('Search error', style: Theme.of(context).textTheme.titleMedium),
+              const SizedBox(height: 8),
+              Text(_searchError!, style: Theme.of(context).textTheme.bodySmall,
+                  textAlign: TextAlign.center),
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (_searchController.text.trim().isNotEmpty && _searchResults.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.search_off, size: 48, color: Colors.grey),
+            const SizedBox(height: 16),
+            Text('No results', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Text(
+              'Try different keywords',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Colors.grey),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (_searchController.text.trim().isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.search, size: 48, color: Colors.grey),
+            const SizedBox(height: 16),
+            Text('Type to search sessions',
+                style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Text(
+              'Search by message content across all sessions',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Colors.grey),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      );
+    }
+
+    return ListView.builder(
+      padding: const EdgeInsets.all(16),
+      itemCount: _searchResults.length,
+      itemBuilder: (context, index) {
+        final result = _searchResults[index];
+        final sessionId = result['session_id'] as String? ?? '';
+        final snippet = result['snippet'] as String? ?? '';
+        final model = result['model'] as String? ?? '';
+        final source = result['source'] as String?;
+
+        return Card(
+          margin: const EdgeInsets.only(bottom: 8),
+          child: ListTile(
+            leading: Icon(Icons.search, color: Colors.blue.shade300),
+            title: Text(
+              _bestSnippet(snippet, 80),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+            subtitle: Row(
+              children: [
+                if (model.isNotEmpty) ...[
+                  Chip(
+                    label: Text(model, style: const TextStyle(fontSize: 10)),
+                    padding: EdgeInsets.zero,
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    visualDensity: VisualDensity.compact,
+                  ),
+                  const SizedBox(width: 4),
+                ],
+                if (source != null && source.isNotEmpty)
+                  Chip(
+                    label: Text(source, style: const TextStyle(fontSize: 10)),
+                    padding: EdgeInsets.zero,
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    visualDensity: VisualDensity.compact,
+                  ),
+              ],
+            ),
+            onTap: () => _onSearchResultTap(result),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _browseBody() {
     if (_loading) {
       return const Center(child: CircularProgressIndicator());
     }

--- a/lib/core/services/connection_manager.dart
+++ b/lib/core/services/connection_manager.dart
@@ -148,6 +148,31 @@ class ApiClient {
     return await _get(baseUrl, 'skills');
   }
 
+  Future<Map<String, dynamic>> searchSessions(String baseUrl, String query) async {
+    final token = await _getSessionToken(baseUrl);
+    final encoded = Uri.encodeQueryComponent(query);
+    final url = '$baseUrl/api/sessions/search?q=$encoded';
+    final res = await _http.get(Uri.parse(url), headers: {
+      'X-Hermes-Session-Token': token,
+    });
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      if (res.statusCode == 401) {
+        _tokenCache.remove(baseUrl);
+        final newToken = await _getSessionToken(baseUrl);
+        final retryRes = await _http.get(
+          Uri.parse('$baseUrl/api/sessions/search?q=$encoded'),
+          headers: {'X-Hermes-Session-Token': newToken},
+        );
+        if (retryRes.statusCode < 200 || retryRes.statusCode >= 300) {
+          throw Exception('HTTP ${retryRes.statusCode}: ${retryRes.body}');
+        }
+        return jsonDecode(retryRes.body) as Map<String, dynamic>;
+      }
+      throw Exception('HTTP ${res.statusCode}: ${res.body}');
+    }
+    return jsonDecode(res.body) as Map<String, dynamic>;
+  }
+
   Future<Map<String, dynamic>> _post(String baseUrl, String endpoint, Map<String, dynamic> body) async {
     final token = await _getSessionToken(baseUrl);
     final url = '$baseUrl/api/$endpoint';


### PR DESCRIPTION
## Summary
Adds search bar to the session list that queries the Hermes FTS5 session search endpoint.

## Features
- **Search toggle**: Tap the search icon in the AppBar to switch to search mode
- **FTS5 search**: Uses GET /api/sessions/search?q=... for full-text search
- **Rich results**: Shows snippets with FTS5 highlight markers stripped, plus model/source chips
- **Smooth navigation**: Tapping a search result loads the session messages in ChatScreen
- **Empty states**: Clear hints for empty query, no results, and error states

## Changes
- Added searchSessions() to ApiClient
- Rewrote session_list_screen.dart with search mode state machine

Closes #11