### PR TITLE
feat: Add Skills browser and session deletion

### DIFF
--- a/lib/core/screens/session_list_screen.dart
+++ b/lib/core/screens/session_list_screen.dart
@@ -138,6 +138,55 @@ class _SessionListScreenState extends State<SessionListScreen> {
         '…';
   }
 
+  Future<void> _deleteSessionNoConfirm(Session session) async {
+    try {
+      await _client!.deleteSession(widget.connection.baseUrl, session.id);
+    } catch (_) {
+      // Session already deleted, just remove from list
+    }
+    setState(() {
+      _sessions.removeWhere((s) => s.id == session.id);
+    });
+  }
+
+  Future<void> _deleteSession(Session session) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete Session'),
+        content: Text('Delete "${session.title}"? This cannot be undone.'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: FilledButton.styleFrom(backgroundColor: Colors.red),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+
+    try {
+      await _client!.deleteSession(widget.connection.baseUrl, session.id);
+      setState(() {
+        _sessions.removeWhere((s) => s.id == session.id);
+      });
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Deleted "${session.title}"')),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Delete failed: $e')),
+        );
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -378,52 +427,83 @@ class _SessionListScreenState extends State<SessionListScreen> {
         itemCount: _sessions.length,
         itemBuilder: (context, index) {
           final session = _sessions[index];
-          return Card(
-            margin: const EdgeInsets.only(bottom: 8),
-            child: ListTile(
-              leading: Icon(
-                Icons.chat,
-                color: session.isActive
-                    ? Colors.blueAccent
-                    : Colors.grey,
-              ),
-              title: Text(session.title, maxLines: 1, overflow: TextOverflow.ellipsis),
-              subtitle: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    '${session.messageCount} messages • ${session.model}',
-                    style: Theme.of(context).textTheme.bodySmall,
-                  ),
-                  if (session.preview.isNotEmpty && session.preview != 'Tap to view session...')
+          return Dismissible(
+            key: Key(session.id),
+            direction: DismissDirection.endToStart,
+            background: Container(
+              alignment: Alignment.centerRight,
+              padding: const EdgeInsets.only(right: 20),
+              color: Colors.red,
+              child: const Icon(Icons.delete, color: Colors.white),
+            ),
+            confirmDismiss: (_) async {
+              final confirmed = await showDialog<bool>(
+                context: context,
+                builder: (ctx) => AlertDialog(
+                  title: const Text('Delete Session'),
+                  content: Text('Delete "${session.title}"?'),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(ctx, false),
+                      child: const Text('Cancel'),
+                    ),
+                    FilledButton(
+                      onPressed: () => Navigator.pop(ctx, true),
+                      style: FilledButton.styleFrom(backgroundColor: Colors.red),
+                      child: const Text('Delete'),
+                    ),
+                  ],
+                ),
+              );
+              return confirmed ?? false;
+            },
+            onDismissed: (_) => _deleteSessionNoConfirm(session),
+            child: Card(
+              margin: const EdgeInsets.only(bottom: 8),
+              child: ListTile(
+                leading: Icon(
+                  Icons.chat,
+                  color: session.isActive ? Colors.blueAccent : Colors.grey,
+                ),
+                title: Text(session.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+                subtitle: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
                     Text(
-                      session.preview,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.grey[500]),
+                      '${session.messageCount} messages • ${session.model}',
+                      style: Theme.of(context).textTheme.bodySmall,
                     ),
-                ],
+                    if (session.preview.isNotEmpty && session.preview != 'Tap to view session...')
+                      Text(
+                        session.preview,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.grey[500]),
+                      ),
+                  ],
+                ),
+                isThreeLine: session.preview.isNotEmpty && session.preview != 'Tap to view session...',
+                trailing: session.isActive
+                    ? Chip(
+                        label: const Text('Active'),
+                        backgroundColor: Colors.blueAccent,
+                        side: BorderSide.none,
+                        padding: const EdgeInsets.symmetric(horizontal: 8),
+                      )
+                    : null,
+                onLongPress: () => _deleteSession(session),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => ChatScreen(
+                        connection: widget.connection,
+                        session: session,
+                      ),
+                    ),
+                  );
+                },
               ),
-              isThreeLine: session.preview.isNotEmpty && session.preview != 'Tap to view session...',
-              trailing: session.isActive
-                  ? Chip(
-                      label: const Text('Active'),
-                      backgroundColor: Colors.blueAccent,
-                      side: BorderSide.none,
-                      padding: const EdgeInsets.symmetric(horizontal: 8),
-                    )
-                  : null,
-              onTap: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => ChatScreen(
-                      connection: widget.connection,
-                      session: session,
-                    ),
-                  ),
-                );
-              },
             ),
           );
         },

--- a/lib/core/screens/settings_screen.dart
+++ b/lib/core/screens/settings_screen.dart
@@ -14,6 +14,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   late ApiClient _client;
   Map<String, dynamic>? _modelInfo;
   Map<String, dynamic>? _modelOptions;
+  List<Map<String, dynamic>> _skills = [];
   bool _loading = true;
   String? _error;
   String? _successMsg;
@@ -48,11 +49,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
       final results = await Future.wait([
         _client.getModelInfo(baseUrl),
         _client.getModelOptions(baseUrl),
+        _client.getSkills(baseUrl),
       ]);
 
       setState(() {
         _modelInfo = results[0] as Map<String, dynamic>;
         _modelOptions = results[1] as Map<String, dynamic>;
+        _skills = (results[2] as List).cast<Map<String, dynamic>>();
         _loading = false;
         _parseModelOptions();
       });
@@ -270,6 +273,40 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   style: const TextStyle(color: Colors.white)),
             ),
           ),
+
+        const SizedBox(height: 16),
+
+        // ---- Section: Skills ----
+        _buildSectionHeader('Installed Skills (${_skills.length})'),
+        if (_skills.isEmpty)
+          const Card(
+            child: Padding(
+              padding: EdgeInsets.all(16),
+              child: Text('No skills found on this instance.',
+                  style: TextStyle(color: Colors.grey)),
+            ),
+          )
+        else
+          ..._skills.map((skill) {
+            final name = skill['name'] as String? ?? '';
+            final enabled = skill['enabled'] as bool? ?? false;
+            final description = skill['description'] as String? ?? '';
+            return Card(
+              margin: const EdgeInsets.only(bottom: 4),
+              child: ListTile(
+                dense: true,
+                title: Text(name, style: const TextStyle(fontFamily: 'monospace', fontSize: 13)),
+                subtitle: description.isNotEmpty
+                    ? Text(description, maxLines: 2, overflow: TextOverflow.ellipsis, style: const TextStyle(fontSize: 12))
+                    : null,
+                trailing: Icon(
+                  enabled ? Icons.check_circle : Icons.block,
+                  color: enabled ? Colors.green : Colors.orange,
+                  size: 18,
+                ),
+              ),
+            );
+          }),
 
         const SizedBox(height: 16),
 

--- a/lib/core/services/connection_manager.dart
+++ b/lib/core/services/connection_manager.dart
@@ -144,8 +144,16 @@ class ApiClient {
     return await _get(baseUrl, 'config');
   }
 
-  Future<Map<String, dynamic>> getSkills(String baseUrl) async {
-    return await _get(baseUrl, 'skills');
+  Future<List<dynamic>> getSkills(String baseUrl) async {
+    final token = await _getSessionToken(baseUrl);
+    final url = '$baseUrl/api/skills';
+    final res = await _http.get(Uri.parse(url), headers: {
+      'X-Hermes-Session-Token': token,
+    });
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      throw Exception('HTTP ${res.statusCode}: ${res.body}');
+    }
+    return jsonDecode(res.body) as List<dynamic>;
   }
 
   Future<Map<String, dynamic>> searchSessions(String baseUrl, String query) async {
@@ -171,6 +179,17 @@ class ApiClient {
       throw Exception('HTTP ${res.statusCode}: ${res.body}');
     }
     return jsonDecode(res.body) as Map<String, dynamic>;
+  }
+
+  Future<void> deleteSession(String baseUrl, String sessionId) async {
+    final token = await _getSessionToken(baseUrl);
+    final url = '$baseUrl/api/sessions/$sessionId';
+    final res = await _http.delete(Uri.parse(url), headers: {
+      'X-Hermes-Session-Token': token,
+    });
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      throw Exception('HTTP ${res.statusCode}: ${res.body}');
+    }
   }
 
   Future<Map<String, dynamic>> _post(String baseUrl, String endpoint, Map<String, dynamic> body) async {


### PR DESCRIPTION
## Summary
Adds two features to complete session management and settings:

### Skills Browser
- Shows installed skills in Settings with name, description, and enable/disable status
- Fetches from GET /api/skills

### Session Deletion
- Swipe-to-delete on session list with red background and confirmation
- Long-press context menu for delete
- Uses DELETE /api/sessions/{id}

Closes #13