### PR TITLE
fix: Session creation auth + name dialog + nav drawer (closes #36)

### DIFF
--- a/lib/core/screens/chat_screen.dart
+++ b/lib/core/screens/chat_screen.dart
@@ -217,7 +217,7 @@ class _ChatScreenState extends State<ChatScreen> {
 
   /// Send message via WebSocket with real-time streaming.
   Future<void> _sendViaWebSocket(String text) async {
-    _ws ??= WsClient(widget.connection.baseUrl);
+    _ws ??= WsClient(widget.connection.baseUrl, token: _client != null ? await _client!.getToken(widget.connection.baseUrl) : null);
     await _ws!.connect();
     await _ws!.resumeSession(widget.session.id);
 
@@ -324,7 +324,7 @@ class _ChatScreenState extends State<ChatScreen> {
 
   /// Fallback: send via REST and poll for response.
   Future<void> _sendViaRest(String text) async {
-    final ws = WsClient(widget.connection.baseUrl);
+    final ws = WsClient(widget.connection.baseUrl, token: _client != null ? await _client!.getToken(widget.connection.baseUrl) : null);
     await ws.connect();
     await ws.resumeSession(widget.session.id);
     await ws.sendMessage(text);

--- a/lib/core/screens/session_list_screen.dart
+++ b/lib/core/screens/session_list_screen.dart
@@ -60,9 +60,43 @@ class _SessionListScreenState extends State<SessionListScreen> {
 
   /// Create a new chat session via WebSocket, then navigate to it.
   Future<void> _createNewSession() async {
+    // Ask for a name first
+    final nameController = TextEditingController(text: 'New Chat');
+    final name = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('New Chat'),
+        content: TextField(
+          controller: nameController,
+          autofocus: true,
+          decoration: const InputDecoration(
+            hintText: 'Session name',
+          ),
+          onSubmitted: (v) => Navigator.pop(ctx, v.trim().isEmpty ? 'New Chat' : v.trim()),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              final n = nameController.text.trim();
+              Navigator.pop(ctx, n.isEmpty ? 'New Chat' : n);
+            },
+            child: const Text('Create'),
+          ),
+        ],
+      ),
+    );
+
+    if (name == null || !mounted) return;
+
     setState(() => _creating = true);
     try {
-      final ws = WsClient(widget.connection.baseUrl);
+      // Get the auth token for WebSocket connection
+      final token = await _client!.getToken(widget.connection.baseUrl);
+      final ws = WsClient(widget.connection.baseUrl, token: token);
       await ws.connect();
       final sessionId = await ws.createSession();
       ws.close();
@@ -205,6 +239,7 @@ class _SessionListScreenState extends State<SessionListScreen> {
     return Scaffold(
       backgroundColor: Colors.black,
       appBar: _searching ? _searchAppBar() : _normalAppBar(),
+      drawer: _buildNavDrawer(),
       body: _searching ? _searchBody() : _browseBody(),
       floatingActionButton: _searching
           ? null
@@ -221,9 +256,95 @@ class _SessionListScreenState extends State<SessionListScreen> {
     );
   }
 
+  Widget _buildNavDrawer() {
+    return Drawer(
+      backgroundColor: const Color(0xFF0D0D0D),
+      child: SafeArea(
+        child: Column(
+          children: [
+            // Header with back button
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+              decoration: const BoxDecoration(
+                border: Border(
+                  bottom: BorderSide(color: Color(0xFFD4AF37), width: 0.5),
+                ),
+              ),
+              child: Row(
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.arrow_back, color: Color(0xFFD4AF37)),
+                    onPressed: () => Navigator.pop(context),
+                    tooltip: 'Back',
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    'HERMES',
+                    style: GoogleFonts.cinzel(
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 6,
+                      fontSize: 20,
+                      color: const Color(0xFFD4AF37),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 8),
+            ListTile(
+              leading: const Icon(Icons.psychology, color: Color(0xFFD4AF37)),
+              title: const Text('Memory'),
+              onTap: () {
+                Navigator.pop(context); // close drawer
+                Navigator.push(context, MaterialPageRoute(
+                  builder: (_) => MemoryScreen(connection: widget.connection),
+                ));
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.schedule, color: Color(0xFFD4AF37)),
+              title: const Text('Cron Jobs'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(context, MaterialPageRoute(
+                  builder: (_) => CronScreen(connection: widget.connection),
+                ));
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.settings, color: Color(0xFFD4AF37)),
+              title: const Text('Settings'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(context, MaterialPageRoute(
+                  builder: (_) => SettingsScreen(connection: widget.connection),
+                ));
+              },
+            ),
+            const Spacer(),
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Text(
+                '${widget.connection.host}:${widget.connection.port}',
+                style: TextStyle(fontSize: 12, color: Colors.grey[700]),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   AppBar _normalAppBar() {
     return AppBar(
       backgroundColor: Colors.black,
+      leading: Builder(
+        builder: (ctx) => IconButton(
+          icon: const Icon(Icons.menu),
+          onPressed: () => Scaffold.of(ctx).openDrawer(),
+        ),
+      ),
       title: Text(
         'HERMES',
         style: GoogleFonts.cinzel(
@@ -235,23 +356,15 @@ class _SessionListScreenState extends State<SessionListScreen> {
       ),
       centerTitle: true,
       actions: [
-        IconButton(icon: const Icon(Icons.psychology), onPressed: () {
-          Navigator.push(context, MaterialPageRoute(
-            builder: (_) => MemoryScreen(connection: widget.connection),
-          ));
-        }, tooltip: 'Memory'),
-        IconButton(icon: const Icon(Icons.schedule), onPressed: () {
-          Navigator.push(context, MaterialPageRoute(
-            builder: (_) => CronScreen(connection: widget.connection),
-          ));
-        }, tooltip: 'Cron'),
-        IconButton(icon: const Icon(Icons.search), onPressed: () => setState(() => _searching = true), tooltip: 'Search'),
-        IconButton(icon: const Icon(Icons.settings), onPressed: () {
-          Navigator.push(context, MaterialPageRoute(
-            builder: (_) => SettingsScreen(connection: widget.connection),
-          ));
-        }, tooltip: 'Settings'),
-        IconButton(icon: const Icon(Icons.refresh), onPressed: _loading ? null : _fetchSessions),
+        IconButton(
+          icon: const Icon(Icons.search),
+          onPressed: () => setState(() => _searching = true),
+          tooltip: 'Search',
+        ),
+        IconButton(
+          icon: const Icon(Icons.refresh),
+          onPressed: _loading ? null : _fetchSessions,
+        ),
       ],
     );
   }

--- a/lib/core/services/connection_manager.dart
+++ b/lib/core/services/connection_manager.dart
@@ -86,6 +86,9 @@ class ApiClient {
     return token;
   }
 
+  /// Public access to the session token for WebSocket auth.
+  Future<String> getToken(String baseUrl) => _getSessionToken(baseUrl);
+
   Future<Map<String, dynamic>> apiGet(String baseUrl, String endpoint) async {
     final token = await _getSessionToken(baseUrl);
     final url = '$baseUrl/api/$endpoint';

--- a/lib/core/services/ws_client.dart
+++ b/lib/core/services/ws_client.dart
@@ -38,6 +38,7 @@ typedef StreamCallback = void Function(StreamEvent event);
 /// WebSocket client for the Hermes JSON-RPC gateway.
 class WsClient {
   final String baseUrl;
+  final String? _token;
   IOWebSocketChannel? _channel;
   bool _connected = false;
   int _nextId = 1;
@@ -51,12 +52,16 @@ class WsClient {
   /// Global stream listener (receives all untargeted events).
   StreamCallback? onStreamEvent;
 
-  WsClient(this.baseUrl);
+  WsClient(this.baseUrl, {String? token}) : _token = token;
 
   /// Connect to the WebSocket gateway.
   Future<void> connect() async {
     if (_connected) return;
-    final wsUrl = '${baseUrl.replaceFirst('http://', 'ws://').replaceFirst('https://', 'wss://')}/api/ws';
+    var wsUrl = '${baseUrl.replaceFirst('http://', 'ws://').replaceFirst('https://', 'wss://')}/api/ws';
+    // Pass session token as query param if available
+    if (_token != null && _token!.isNotEmpty) {
+      wsUrl = '$wsUrl?token=${Uri.encodeQueryComponent(_token!)}';
+    }
     _channel = IOWebSocketChannel.connect(Uri.parse(wsUrl));
     _connected = true;
     _channel!.stream.listen(_handleMessage, onDone: () {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hermes_android
 description: "Hermes Agent — Multi-Session Chat via REST API"
 publish_to: 'none'
-version: 0.3.0+30
+version: 0.3.1+31
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
Closes #36

### Session creation auth fix
- WsClient now accepts optional `token` parameter
- Token passed as `?token=...` query param on WebSocket connect
- `ApiClient.getToken()` made public for WS auth
- Chat screen also passes token to WsClient for real-time streaming

### New session name dialog
- Dialog appears before creating a session
- Pre-filled with 'New Chat', editable text field
- Enter/submit creates session with chosen name
- Cancel dismisses the dialog

### Navigation drawer
- Burger menu (☰) in app bar opens left drawer
- Drawer contains: Memory, Cron Jobs, Settings
- Back button inside drawer header (not in app bar)
- Connection host:port shown at drawer bottom
- Drawer closes on tap, then navigates to selected screen