### PR TITLE
fix: Handle 404 for new sessions + clearer WS error

### DIFF
--- a/lib/core/screens/chat_screen.dart
+++ b/lib/core/screens/chat_screen.dart
@@ -100,13 +100,24 @@ class _ChatScreenState extends State<ChatScreen> {
         widget.connection.baseUrl,
         widget.session.id,
       );
+      if (!mounted) return;
       setState(() {
         _messages = messages;
         _loading = false;
       });
     } catch (e) {
+      if (!mounted) return;
+      // 404 means new session — just show empty chat
+      final errStr = e.toString();
+      if (errStr.contains('404') || errStr.contains('not found')) {
+        setState(() {
+          _messages = [];
+          _loading = false;
+        });
+        return;
+      }
       setState(() {
-        _error = e.toString();
+        _error = errStr;
         _loading = false;
       });
     }
@@ -396,7 +407,6 @@ class _ChatScreenState extends State<ChatScreen> {
       _streaming = false;
       _streamedContent = '';
       _streamMessageId = -1;
-      // Remove optimistic user message
       if (_messages.isNotEmpty &&
           _messages[0]['role'] == 'user' &&
           _messages[0]['content'] == text) {
@@ -405,11 +415,15 @@ class _ChatScreenState extends State<ChatScreen> {
     });
 
     if (mounted) {
+      final msg = e.toString().contains('Connection closed')
+          ? 'WebSocket blocked — dashboard only allows WS from localhost.\n'
+              'Run hermes dashboard --insecure --bind 0.0.0.0'
+          : 'Send failed: $e';
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Send failed: $e'),
+          content: Text(msg, style: const TextStyle(fontSize: 13)),
           backgroundColor: Colors.orange,
-          duration: const Duration(seconds: 3),
+          duration: const Duration(seconds: 6),
         ),
       );
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hermes_android
 description: "Hermes Agent — Multi-Session Chat via REST API"
 publish_to: 'none'
-version: 0.3.2+32
+version: 0.3.3+33
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
### Fixes

- New sessions (fresh UUID) no longer show 'session not found 404' — empty chat state shown instead
- WebSocket 'Connection closed' error now explains the root cause: dashboard blocks WS from non-localhost IPs
- Added mounted guards before setState in async callbacks

### Server-side requirement

The dashboard WebSocket endpoint only accepts connections from localhost (127.0.0.1, ::1). From the Android phone on LAN, WS connections are rejected. To enable full chat functionality, the dashboard needs to allow LAN WebSocket connections.