### PR TITLE
docs: README with setup instructions, fix WS error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,44 @@
 # Hermes Android App
 
-> **Work in progress** — Mobile client for connecting to a remote [Hermes Agent](https://hermes-agent.nousresearch.com) dashboard.
-
-## Overview
-
-The Hermes Android App is a Flutter-based mobile client that connects to a remote Hermes Agent dashboard over HTTP/WebSocket. It supports managing multiple concurrent sessions, viewing session history, and interacting with the Hermes Agent from your Android device.
+Mobile client for [Hermes Agent](https://hermes-agent.nousresearch.com) — connect to your dashboard from your Android phone over WiFi.
 
 ## Features
 
-- **Remote Connection Management** — Save, edit, and switch between multiple remote Hermes dashboards
-- **Session History** — Browse and view existing sessions via the REST API
-- **Dark Mode** — Material 3 dark theme by default
-- **Multi-Session Support** — Tab-based navigation between active conversations
+- **Gold/black Hermes branding** — Cinzel wordmark, gold accents, dark theme
+- **Messaging-app style session list** — circular avatars, relative timestamps, message previews
+- **Real-time WebSocket streaming** — token-by-token assistant responses
+- **New chat creation** — name your session and start chatting
+- **Full dashboard access** — Memory browser, Cron jobs, Settings, Skills
+- **Media attachments** — photo library and camera picker
+- **Responsive layout** — phone and tablet support
 
-## Architecture
+## Setup
 
-```
-┌─────────────┐       HTTPS/WS       ┌─────────────────────┐
-│             │ ─────────────────────>│  Hermes Dashboard   │
-│  Android App │   REST API + PTY    │  (port 9119)        │
-│             │                      │                   │
-└─────────────┘                      └─────────────────────┐
-                                                           │
-                                                           ▼
-                                                  ┌─────────────────────┐
-                                                  │  Hermes Agent Core  │
-                                                  │  (LLM + Tools)      │
-                                                  └─────────────────────┘
+### 1. Start the Hermes dashboard
+
+The dashboard must bind to all interfaces so the Android app can reach it over WiFi:
+
+```bash
+hermes dashboard --insecure --host 0.0.0.0 --port 9119
 ```
 
-### Tech Stack
+> **Important:** `--host 0.0.0.0` is required. Without it the dashboard's WebSocket only accepts connections from localhost, and chat will fail with "Connection closed."
 
-- **Flutter 3.44** / **Dart 3.12**
-- **Material 3** dark theme
-- **SharedPreferences** for local connection persistence
-- **HTTP** for REST API communication
-- **WebSocket** (PTY) for real-time chat interaction
+### 2. Find your server IP
 
-## Prerequisites
+On the machine running the dashboard:
 
-- Flutter 3.44+
-- Dart 3.12+
-- Android SDK 36+
+```bash
+# macOS / Linux
+ipconfig getifaddr en0   # or: hostname -I | awk '{print $1}'
+```
+
+### 3. Connect from the app
+
+1. Open the Hermes Android app
+2. Tap **+** to add a connection
+3. Enter a label, your server's IP, and port `9119`
+4. Tap the connection to see your sessions
 
 ## Development
 
@@ -51,32 +48,79 @@ flutter pub get
 flutter run -d android
 ```
 
-### Building the APK
+### Build release APK
 
 ```bash
-flutter build apk --debug
+flutter build apk --release --split-per-abi
+# Output: build/app/outputs/flutter-apk/app-*-release.apk
 ```
 
-## Connection Configuration
+## Architecture
 
-To connect to a local Hermes dashboard:
+```
+┌──────────────┐     HTTP + WebSocket     ┌────────────────────┐
+│  Android App  │ ───────────────────────> │  Hermes Dashboard   │
+│  (Flutter)    │    REST API + WS         │  (port 9119)        │
+└──────────────┘                           └────────────────────┘
+```
 
-1. Ensure your dashboard is running with `hermes dashboard --insecure`
-2. Add a connection with your host and port (default: `9119`)
-3. Tap the connection to browse sessions
+- **REST API** — sessions, config, models, skills, memory, cron
+- **WebSocket JSON-RPC** — real-time chat streaming via `/api/ws`
+- **Session token** — auto-discovered from dashboard SPA page
+
+## Tech Stack
+
+- Flutter 3.44 / Dart 3.12
+- Material 3 dark theme with gold accents
+- `flutter_markdown` for message rendering
+- `flutter_local_notifications` for push
+- `google_fonts` (Cinzel) for branding
+- `image_picker` for media attachments
+- `web_socket_channel` for JSON-RPC streaming
 
 ## Project Structure
 
 ```
 lib/
+├── main.dart                          # Entry point + HomeScreen + HermesHeader
 ├── core/
 │   ├── models/
-│   │   └── connection.dart      # Connection data model
+│   │   ├── connection.dart            # SavedConnection model
+│   │   └── session.dart               # Session model
+│   ├── screens/
+│   │   ├── session_list_screen.dart   # Messaging-style session browser
+│   │   ├── chat_screen.dart           # Chat with WS streaming + media
+│   │   ├── settings_screen.dart       # Model selection + skills
+│   │   ├── memory_screen.dart         # Memory viewer
+│   │   └── cron_screen.dart           # Cron job manager
 │   ├── services/
-│   │   └── connection_manager.dart # Connection persistence + API client
-│   └── screens/                   # Screen widgets (coming)
-└── main.dart                      # App entry point
+│   │   ├── connection_manager.dart    # Connection persistence + ApiClient
+│   │   ├── ws_client.dart             # JSON-RPC WebSocket client
+│   │   └── notification_service.dart  # Push notification service
+│   └── utils/
+│       └── responsive.dart            # Phone/tablet breakpoints
+└── assets/
+    └── icon/
+        └── icon.png                   # App icon source
 ```
+
+## Troubleshooting
+
+### "Connection closed" when sending messages
+
+The dashboard WebSocket only accepts clients from private network IPs when bound to `0.0.0.0`. Ensure you're using:
+
+```bash
+hermes dashboard --insecure --bind 0.0.0.0
+```
+
+### "Session not found" for new sessions
+
+New sessions show an empty chat until the first message is sent. The agent creates the session file on disk when you send your first prompt.
+
+### Can't find the server
+
+Make sure your phone and the dashboard host are on the same WiFi network. Check the firewall on the dashboard host isn't blocking port 9119.
 
 ## License
 

--- a/lib/core/screens/chat_screen.dart
+++ b/lib/core/screens/chat_screen.dart
@@ -417,7 +417,7 @@ class _ChatScreenState extends State<ChatScreen> {
     if (mounted) {
       final msg = e.toString().contains('Connection closed')
           ? 'WebSocket blocked — dashboard only allows WS from localhost.\n'
-              'Run hermes dashboard --insecure --bind 0.0.0.0'
+              'Run: hermes dashboard --insecure --host 0.0.0.0'
           : 'Send failed: $e';
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hermes_android
 description: "Hermes Agent — Multi-Session Chat via REST API"
 publish_to: 'none'
-version: 0.3.3+33
+version: 0.3.4+34
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
## Changes

- Comprehensive README with setup guide, architecture, troubleshooting
- Fix WS error message to use correct flag: `--host 0.0.0.0` (not `--bind`)
- Server-side fix applied to hermes-agent: WebSocket now allows private network clients (10.x, 172.16-31.x, 192.168.x) when dashboard is bound to all-interfaces