### PR TITLE
feat: Dark mode toggle + --tui requirement in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Mobile client for [Hermes Agent](https://hermes-agent.nousresearch.com) — conn
 The dashboard must bind to all interfaces so the Android app can reach it over WiFi:
 
 ```bash
-hermes dashboard --insecure --host 0.0.0.0 --port 9119
+hermes dashboard --insecure --host 0.0.0.0 --tui --port 9119
 ```
 
 > **Important:** `--host 0.0.0.0` is required. Without it the dashboard's WebSocket only accepts connections from localhost, and chat will fail with "Connection closed."

--- a/lib/core/screens/chat_screen.dart
+++ b/lib/core/screens/chat_screen.dart
@@ -416,8 +416,8 @@ class _ChatScreenState extends State<ChatScreen> {
 
     if (mounted) {
       final msg = e.toString().contains('Connection closed')
-          ? 'WebSocket blocked — dashboard only allows WS from localhost.\n'
-              'Run: hermes dashboard --insecure --host 0.0.0.0'
+          ? 'WebSocket blocked.\n'
+              'Run: hermes dashboard --insecure --host 0.0.0.0 --tui'
           : 'Send failed: $e';
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(

--- a/lib/core/screens/settings_screen.dart
+++ b/lib/core/screens/settings_screen.dart
@@ -1,6 +1,8 @@
 /// Settings screen for model selection, theme toggle, and app info.
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../services/connection_manager.dart';
+import '../../main.dart';
 
 class SettingsScreen extends StatefulWidget {
   final SavedConnection connection;
@@ -327,16 +329,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
         // ---- Section: Theme ----
         _buildSectionHeader('Appearance'),
-        SwitchListTile(
-          title: const Text('Dark Mode'),
-          subtitle: const Text('Follow system theme'),
-          value: Theme.of(context).brightness == Brightness.dark,
-          onChanged: (_) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Dark mode follows system setting')),
-            );
-          },
-        ),
+        _ThemeToggle(),
         const SizedBox(height: 16),
 
         // ---- Section: Connection ----
@@ -426,6 +419,61 @@ class _SettingsScreenState extends State<SettingsScreen> {
       ),
       items: items,
       onChanged: onChanged,
+    );
+  }
+}
+
+/// Theme toggle widget that cycles through system → dark → light.
+class _ThemeToggle extends StatefulWidget {
+  @override
+  State<_ThemeToggle> createState() => _ThemeToggleState();
+}
+
+class _ThemeToggleState extends State<_ThemeToggle> {
+  String _mode = 'system';
+
+  @override
+  void initState() {
+    super.initState();
+    _loadMode();
+  }
+
+  Future<void> _loadMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    setState(() => _mode = prefs.getString('theme_mode') ?? 'system');
+  }
+
+  Future<void> _cycleMode() async {
+    final next = _mode == 'system' ? 'dark' : _mode == 'dark' ? 'light' : 'system';
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('theme_mode', next);
+    setState(() => _mode = next);
+
+    // Rebuild the app to apply the new theme
+    if (mounted) {
+      final rootCtx = context.findAncestorStateOfType<HermesAppState>();
+      rootCtx?.setState(() {});
+    }
+  }
+
+  String get _label {
+    switch (_mode) {
+      case 'dark':
+        return 'Dark';
+      case 'light':
+        return 'Light';
+      default:
+        return 'System';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SwitchListTile(
+      title: Text('Theme: $_label'),
+      subtitle: const Text('Tap to cycle: system → dark → light'),
+      value: _mode == 'dark' || (_mode == 'system' && MediaQuery.of(context).platformBrightness == Brightness.dark),
+      onChanged: (_) => _cycleMode(),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,17 +14,65 @@ void main() async {
   runApp(HermesApp(connManager: connManager));
 }
 
-class HermesApp extends StatelessWidget {
+class HermesApp extends StatefulWidget {
   final ConnectionManager connManager;
   const HermesApp({required this.connManager, super.key});
 
   @override
+  State<HermesApp> createState() => HermesAppState();
+
+  /// Get current theme mode from preferences.
+  static ThemeMode getThemeMode(SharedPreferences prefs) {
+    final stored = prefs.getString('theme_mode') ?? 'system';
+    switch (stored) {
+      case 'dark':
+        return ThemeMode.dark;
+      case 'light':
+        return ThemeMode.light;
+      default:
+        return ThemeMode.system;
+    }
+  }
+
+  /// Set theme mode in preferences.
+  static Future<void> setThemeMode(SharedPreferences prefs, ThemeMode mode) async {
+    final value = mode == ThemeMode.dark ? 'dark' : mode == ThemeMode.light ? 'light' : 'system';
+    await prefs.setString('theme_mode', value);
+  }
+}
+
+class HermesAppState extends State<HermesApp> {
+  @override
   Widget build(BuildContext context) {
-    const gold = Color(0xFFD4AF37); // Hermes gold
+    const gold = Color(0xFFD4AF37);
 
     return MaterialApp(
       title: 'Hermes Agent',
+      themeMode: HermesApp.getThemeMode(widget.connManager.prefs),
       theme: ThemeData(
+        colorSchemeSeed: gold,
+        brightness: Brightness.light,
+        useMaterial3: true,
+        scaffoldBackgroundColor: const Color(0xFFFAFAFA),
+        appBarTheme: const AppBarTheme(
+          backgroundColor: Colors.white,
+          elevation: 0,
+          centerTitle: true,
+        ),
+        cardTheme: CardThemeData(
+          color: Colors.white,
+          elevation: 0,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+            side: BorderSide(color: Colors.grey.withValues(alpha: 0.15)),
+          ),
+        ),
+        floatingActionButtonTheme: const FloatingActionButtonThemeData(
+          backgroundColor: gold,
+          foregroundColor: Colors.white,
+        ),
+      ),
+      darkTheme: ThemeData(
         colorSchemeSeed: gold,
         brightness: Brightness.dark,
         useMaterial3: true,
@@ -46,9 +94,8 @@ class HermesApp extends StatelessWidget {
           backgroundColor: gold,
           foregroundColor: Colors.black,
         ),
-        iconTheme: const IconThemeData(color: gold),
       ),
-      home: HomeScreen(connManager: connManager),
+      home: HomeScreen(connManager: widget.connManager),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hermes_android
 description: "Hermes Agent — Multi-Session Chat via REST API"
 publish_to: 'none'
-version: 0.3.4+34
+version: 0.3.5+35
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
## Changes

- Working dark mode toggle in Settings (system → dark → light)
- HermesApp is now a StatefulWidget with ThemeMode support
- Light theme defined alongside dark theme (white/gold)
- README updated to require --tui flag
- WS error message updated to mention --tui