### PR TITLE
fix: Use WS session.create so resumeSession finds the session

### DIFF
--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -1,0 +1,42 @@
+# Release Checklist
+
+Run through this before every release PR. Mark each item ✅ or ⚠️.
+
+## Analysis
+- [ ] `flutter analyze` — zero errors
+- [ ] `flutter pub outdated` — key deps current
+- [ ] `flutter build apk --release --split-per-abi` — clean build
+
+## Architecture
+- [ ] State management consistency (no orphaned setState vs Riverpod)
+- [ ] No orphaned imports
+- [ ] Error handling on all network calls
+- [ ] `dispose()` on all `StatefulWidget`s with controllers/timers
+- [ ] WebSocket lifecycle (connect/dispose)
+
+## UX
+- [ ] Error states visible (not silent failures)
+- [ ] Loading indicators on network calls
+- [ ] Responsive layout (phone + tablet)
+- [ ] Dark mode follows system
+- [ ] Input validation (no empty submits)
+
+## Security
+- [ ] Session token auto-discovery
+- [ ] No hardcoded API keys
+- [ ] Proper URL scheme validation
+
+## Release
+- [ ] Version bumped in `pubspec.yaml`
+- [ ] CHANGELOG.md updated
+- [ ] CI/CD builds clean APK
+- [ ] GitHub Actions workflow passes
+- [ ] Tag pushed (`git tag v0.x.y && git push origin main --tags`)
+
+## Testing (Android Emulator / Device)
+- [ ] Connect to dashboard
+- [ ] Browse sessions
+- [ ] Send message → see response
+- [ ] Delete session
+- [ ] Search sessions
+- [ ] Settings → model selection

--- a/lib/core/screens/session_list_screen.dart
+++ b/lib/core/screens/session_list_screen.dart
@@ -3,8 +3,8 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import '../services/connection_manager.dart';
+import '../services/ws_client.dart';
 import '../utils/responsive.dart';
-import 'package:uuid/uuid.dart';
 import 'chat_screen.dart';
 import 'settings_screen.dart';
 import 'memory_screen.dart';
@@ -57,10 +57,7 @@ class _SessionListScreenState extends State<SessionListScreen> {
     }
   }
 
-  /// Create a new chat by navigating straight to a ChatScreen with a fresh UUID.
-  /// The Hermes agent creates the session implicitly on the first message send.
-  static const _uuid = Uuid();
-
+  /// Create a new chat session via WebSocket, then navigate to it.
   Future<void> _createNewSession() async {
     // Ask for a name first
     final nameController = TextEditingController(text: 'New Chat');
@@ -89,29 +86,49 @@ class _SessionListScreenState extends State<SessionListScreen> {
 
     if (name == null || !mounted) return;
 
-    // Generate a fresh session ID and open the chat screen directly.
-    // The session will be persisted by the agent on first message.
-    final sessionId = _uuid.v4();
-    final session = Session(
-      id: sessionId,
-      title: name,
-      model: '',
-      messageCount: 0,
-      isActive: true,
-      preview: '',
-      createdAt: DateTime.now().toIso8601String(),
-    );
+    try {
+      // Create the session server-side via WebSocket
+      final token = await _client!.getToken(widget.connection.baseUrl);
+      final ws = WsClient(widget.connection.baseUrl, token: token);
+      await ws.connect();
+      final sessionId = await ws.createSession();
+      ws.close();
 
-    if (!mounted) return;
-    Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (_) => ChatScreen(
-          connection: widget.connection,
-          session: session,
+      if (!mounted) return;
+
+      // Refresh to pick up the new session
+      await _fetchSessions();
+
+      // Open the chat
+      final session = Session(
+        id: sessionId,
+        title: name,
+        model: '',
+        messageCount: 0,
+        isActive: true,
+        preview: '',
+        createdAt: DateTime.now().toIso8601String(),
+      );
+
+      if (!mounted) return;
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => ChatScreen(
+            connection: widget.connection,
+            session: session,
+          ),
         ),
-      ),
-    );
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Failed: $e'),
+          backgroundColor: Colors.orange,
+        ),
+      );
+    }
   }
 
   Future<void> _doSearch(String query) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hermes_android
 description: "Hermes Agent — Multi-Session Chat via REST API"
 publish_to: 'none'
-version: 0.3.5+35
+version: 0.3.6+36
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
Now that WebSocket works from LAN (v0.3.5 server fix), new sessions are created server-side via `session.create` JSON-RPC. This registers the session in the server's session DB so `session.resume` finds it when the chat screen opens.

Previously the app generated a client-side UUID which the server didn't know about, causing "JsonRpcError session not found" on first message.