### PR TITLE
feat: Skills in drawer, three-way theme toggle, light mode fix

### DIFF
--- a/lib/core/screens/chat_screen.dart
+++ b/lib/core/screens/chat_screen.dart
@@ -432,9 +432,7 @@ class _ChatScreenState extends State<ChatScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.black,
       appBar: AppBar(
-        backgroundColor: Colors.black,
         title: Text(
           widget.session.title,
           maxLines: 1,

--- a/lib/core/screens/session_list_screen.dart
+++ b/lib/core/screens/session_list_screen.dart
@@ -9,6 +9,7 @@ import 'chat_screen.dart';
 import 'settings_screen.dart';
 import 'memory_screen.dart';
 import 'cron_screen.dart';
+import 'skills_screen.dart';
 
 class SessionListScreen extends StatefulWidget {
   final SavedConnection connection;
@@ -236,7 +237,6 @@ class _SessionListScreenState extends State<SessionListScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.black,
       appBar: _searching ? _searchAppBar() : _normalAppBar(),
       drawer: _buildNavDrawer(),
       body: _searching ? _searchBody() : _browseBody(),
@@ -252,7 +252,6 @@ class _SessionListScreenState extends State<SessionListScreen> {
 
   Widget _buildNavDrawer() {
     return Drawer(
-      backgroundColor: const Color(0xFF0D0D0D),
       child: SafeArea(
         child: Column(
           children: [
@@ -307,6 +306,16 @@ class _SessionListScreenState extends State<SessionListScreen> {
               },
             ),
             ListTile(
+              leading: const Icon(Icons.extension, color: Color(0xFFD4AF37)),
+              title: const Text('Skills'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(context, MaterialPageRoute(
+                  builder: (_) => SkillsScreen(connection: widget.connection),
+                ));
+              },
+            ),
+            ListTile(
               leading: const Icon(Icons.settings, color: Color(0xFFD4AF37)),
               title: const Text('Settings'),
               onTap: () {
@@ -332,7 +341,6 @@ class _SessionListScreenState extends State<SessionListScreen> {
 
   AppBar _normalAppBar() {
     return AppBar(
-      backgroundColor: Colors.black,
       leading: Builder(
         builder: (ctx) => IconButton(
           icon: const Icon(Icons.menu),
@@ -365,7 +373,6 @@ class _SessionListScreenState extends State<SessionListScreen> {
 
   AppBar _searchAppBar() {
     return AppBar(
-      backgroundColor: Colors.black,
       title: TextField(
         controller: _searchController,
         autofocus: true,

--- a/lib/core/screens/settings_screen.dart
+++ b/lib/core/screens/settings_screen.dart
@@ -293,40 +293,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
         const SizedBox(height: 16),
 
-        // ---- Section: Skills ----
-        _buildSectionHeader('Installed Skills (${_skills.length})'),
-        if (_skills.isEmpty)
-          const Card(
-            child: Padding(
-              padding: EdgeInsets.all(16),
-              child: Text('No skills found on this instance.',
-                  style: TextStyle(color: Colors.grey)),
-            ),
-          )
-        else
-          ..._skills.map((skill) {
-            final name = skill['name'] as String? ?? '';
-            final enabled = skill['enabled'] as bool? ?? false;
-            final description = skill['description'] as String? ?? '';
-            return Card(
-              margin: const EdgeInsets.only(bottom: 4),
-              child: ListTile(
-                dense: true,
-                title: Text(name, style: const TextStyle(fontFamily: 'monospace', fontSize: 13)),
-                subtitle: description.isNotEmpty
-                    ? Text(description, maxLines: 2, overflow: TextOverflow.ellipsis, style: const TextStyle(fontSize: 12))
-                    : null,
-                trailing: Icon(
-                  enabled ? Icons.check_circle : Icons.block,
-                  color: enabled ? Colors.green : Colors.orange,
-                  size: 18,
-                ),
-              ),
-            );
-          }),
-
-        const SizedBox(height: 16),
-
         // ---- Section: Theme ----
         _buildSectionHeader('Appearance'),
         _ThemeToggle(),
@@ -423,7 +389,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 }
 
-/// Theme toggle widget that cycles through system → dark → light.
+/// Theme toggle with three-way segmented control: System | Dark | Light.
 class _ThemeToggle extends StatefulWidget {
   @override
   State<_ThemeToggle> createState() => _ThemeToggleState();
@@ -443,37 +409,30 @@ class _ThemeToggleState extends State<_ThemeToggle> {
     setState(() => _mode = prefs.getString('theme_mode') ?? 'system');
   }
 
-  Future<void> _cycleMode() async {
-    final next = _mode == 'system' ? 'dark' : _mode == 'dark' ? 'light' : 'system';
+  Future<void> _setMode(String mode) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString('theme_mode', next);
-    setState(() => _mode = next);
-
-    // Rebuild the app to apply the new theme
-    if (mounted) {
-      final rootCtx = context.findAncestorStateOfType<HermesAppState>();
-      rootCtx?.setState(() {});
-    }
-  }
-
-  String get _label {
-    switch (_mode) {
-      case 'dark':
-        return 'Dark';
-      case 'light':
-        return 'Light';
-      default:
-        return 'System';
-    }
+    await prefs.setString('theme_mode', mode);
+    setState(() => _mode = mode);
+    final rootCtx = context.findAncestorStateOfType<HermesAppState>();
+    rootCtx?.setState(() {});
   }
 
   @override
   Widget build(BuildContext context) {
-    return SwitchListTile(
-      title: Text('Theme: $_label'),
-      subtitle: const Text('Tap to cycle: system → dark → light'),
-      value: _mode == 'dark' || (_mode == 'system' && MediaQuery.of(context).platformBrightness == Brightness.dark),
-      onChanged: (_) => _cycleMode(),
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: SegmentedButton<String>(
+        segments: const [
+          ButtonSegment(value: 'system', label: Text('System'), icon: Icon(Icons.brightness_auto, size: 18)),
+          ButtonSegment(value: 'dark', label: Text('Dark'), icon: Icon(Icons.dark_mode, size: 18)),
+          ButtonSegment(value: 'light', label: Text('Light'), icon: Icon(Icons.light_mode, size: 18)),
+        ],
+        selected: {_mode},
+        onSelectionChanged: (s) => _setMode(s.first),
+        style: ButtonStyle(
+          visualDensity: VisualDensity.compact,
+        ),
+      ),
     );
   }
 }

--- a/lib/core/screens/skills_screen.dart
+++ b/lib/core/screens/skills_screen.dart
@@ -1,0 +1,115 @@
+/// Skills browser — list installed skills with enabled/disabled status.
+import 'package:flutter/material.dart';
+import '../services/connection_manager.dart';
+
+class SkillsScreen extends StatefulWidget {
+  final SavedConnection connection;
+  const SkillsScreen({required this.connection, super.key});
+
+  @override
+  State<SkillsScreen> createState() => _SkillsScreenState();
+}
+
+class _SkillsScreenState extends State<SkillsScreen> {
+  late ApiClient _client;
+  List<Map<String, dynamic>> _skills = [];
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _client = ApiClient();
+    _load();
+  }
+
+  @override
+  void dispose() {
+    _client.close();
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    setState(() { _loading = true; _error = null; });
+    try {
+      final raw = await _client.getSkills(widget.connection.baseUrl);
+      if (!mounted) return;
+      setState(() {
+        _skills = raw.whereType<Map<String, dynamic>>().toList();
+        _loading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() { _error = e.toString(); _loading = false; });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Skills (${_skills.length})'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: _loading ? null : _load,
+          ),
+        ],
+      ),
+      body: _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_loading) return const Center(child: CircularProgressIndicator());
+    if (_error != null) {
+      return Center(child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(mainAxisSize: MainAxisSize.min, children: [
+          const Icon(Icons.error_outline, size: 48, color: Colors.orange),
+          const SizedBox(height: 16),
+          Text('Failed to load skills', style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 8),
+          Text(_error!, style: Theme.of(context).textTheme.bodySmall, textAlign: TextAlign.center),
+          const SizedBox(height: 24),
+          ElevatedButton(onPressed: _load, child: const Text('Retry')),
+        ]),
+      ));
+    }
+    if (_skills.isEmpty) {
+      return Center(child: Column(mainAxisSize: MainAxisSize.min, children: [
+        Icon(Icons.extension_off, size: 48, color: Colors.grey[600]),
+        const SizedBox(height: 16),
+        Text('No skills found', style: Theme.of(context).textTheme.titleLarge),
+      ]));
+    }
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: _skills.length,
+        itemBuilder: (_, i) {
+          final skill = _skills[i];
+          final name = skill['name'] as String? ?? '';
+          final enabled = skill['enabled'] as bool? ?? false;
+          final description = skill['description'] as String? ?? '';
+          return Card(
+            margin: const EdgeInsets.only(bottom: 6),
+            child: ListTile(
+              dense: true,
+              title: Text(name, style: const TextStyle(fontFamily: 'monospace', fontSize: 13)),
+              subtitle: description.isNotEmpty
+                  ? Text(description, maxLines: 2, overflow: TextOverflow.ellipsis, style: const TextStyle(fontSize: 12))
+                  : null,
+              trailing: Icon(
+                enabled ? Icons.check_circle : Icons.block,
+                color: enabled ? Colors.green : Colors.orange,
+                size: 18,
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -242,9 +242,7 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.black,
       appBar: AppBar(
-        backgroundColor: Colors.black,
         title: Text(
           'HERMES',
           style: GoogleFonts.cinzel(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hermes_android
 description: "Hermes Agent — Multi-Session Chat via REST API"
 publish_to: 'none'
-version: 0.3.6+36
+version: 0.3.7+37
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
### Skills in drawer
- Skills extracted from settings into own SkillsScreen
- Accessible from burger menu drawer alongside Memory, Cron, Settings

### Three-way theme toggle
- SegmentedButton: System | Dark | Light
- No more confusing binary switch
- Rebuilds app immediately on selection

### Light mode now works everywhere
- Removed hardcoded Colors.black from all Scaffolds/AppBars
- All screens respect the theme (light = white/gold, dark = black/gold)