### PR TITLE
fix: Dynamic version display + tolerant resumeSession

### DIFF
--- a/lib/core/screens/chat_screen.dart
+++ b/lib/core/screens/chat_screen.dart
@@ -230,7 +230,12 @@ class _ChatScreenState extends State<ChatScreen> {
   Future<void> _sendViaWebSocket(String text) async {
     _ws ??= WsClient(widget.connection.baseUrl, token: _client != null ? await _client!.getToken(widget.connection.baseUrl) : null);
     await _ws!.connect();
-    await _ws!.resumeSession(widget.session.id);
+    try {
+      await _ws!.resumeSession(widget.session.id);
+    } catch (_) {
+      // Session may not exist yet on server (e.g. offline-created session).
+      // The agent will create it implicitly on the first prompt.
+    }
 
     // Track streaming state
     _streamedContent = '';
@@ -337,7 +342,11 @@ class _ChatScreenState extends State<ChatScreen> {
   Future<void> _sendViaRest(String text) async {
     final ws = WsClient(widget.connection.baseUrl, token: _client != null ? await _client!.getToken(widget.connection.baseUrl) : null);
     await ws.connect();
-    await ws.resumeSession(widget.session.id);
+    try {
+      await ws.resumeSession(widget.session.id);
+    } catch (_) {
+      // Session may not exist yet — agent creates on first prompt
+    }
     await ws.sendMessage(text);
     ws.close();
 

--- a/lib/core/screens/session_list_screen.dart
+++ b/lib/core/screens/session_list_screen.dart
@@ -96,11 +96,8 @@ class _SessionListScreenState extends State<SessionListScreen> {
       ws.close();
 
       if (!mounted) return;
-
-      // Refresh to pick up the new session
       await _fetchSessions();
 
-      // Open the chat
       final session = Session(
         id: sessionId,
         title: name,
@@ -123,12 +120,44 @@ class _SessionListScreenState extends State<SessionListScreen> {
       );
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('Failed: $e'),
-          backgroundColor: Colors.orange,
-        ),
-      );
+      final errStr = e.toString();
+      // If WS is unavailable, fall back to client-side UUID with warning
+      if (errStr.contains('Connection closed') || errStr.contains('Not connected')) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('WS unavailable — creating offline session. '
+                'Ensure dashboard is running with --tui'),
+            backgroundColor: Colors.orange,
+            duration: const Duration(seconds: 5),
+          ),
+        );
+        // Fall back to direct navigation with UUID
+        final session = Session(
+          id: '${DateTime.now().millisecondsSinceEpoch}',
+          title: name,
+          model: '',
+          messageCount: 0,
+          isActive: true,
+          preview: '',
+          createdAt: DateTime.now().toIso8601String(),
+        );
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => ChatScreen(
+              connection: widget.connection,
+              session: session,
+            ),
+          ),
+        );
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Failed: $errStr'),
+            backgroundColor: Colors.orange,
+          ),
+        );
+      }
     }
   }
 

--- a/lib/core/screens/settings_screen.dart
+++ b/lib/core/screens/settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../services/connection_manager.dart';
 import '../../main.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 class SettingsScreen extends StatefulWidget {
   final SavedConnection connection;
@@ -321,26 +322,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
         // ---- Section: About ----
         _buildSectionHeader('About'),
-        const Card(
-          child: Padding(
-            padding: EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('Hermes Agent for Android',
-                    style: TextStyle(fontWeight: FontWeight.bold)),
-                SizedBox(height: 4),
-                Text('Version 0.1.0'),
-                SizedBox(height: 8),
-                Text(
-                  'Browse and manage your Hermes Agent sessions from your phone. '
-                  'Connects to a Hermes dashboard running on your local network.',
-                  style: TextStyle(color: Colors.grey),
-                ),
-              ],
-            ),
-          ),
-        ),
+        _AboutCard(),
       ],
     );
   }
@@ -385,6 +367,55 @@ class _SettingsScreenState extends State<SettingsScreen> {
       ),
       items: items,
       onChanged: onChanged,
+    );
+  }
+}
+
+/// About card that reads the real version from package_info_plus.
+class _AboutCard extends StatefulWidget {
+  @override
+  State<_AboutCard> createState() => _AboutCardState();
+}
+
+class _AboutCardState extends State<_AboutCard> {
+  String _version = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _loadVersion();
+  }
+
+  Future<void> _loadVersion() async {
+    try {
+      final info = await PackageInfo.fromPlatform();
+      setState(() => _version = '${info.version}+${info.buildNumber}');
+    } catch (_) {
+      setState(() => _version = 'unknown');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Hermes Agent for Android',
+                style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 4),
+            Text('Version ${_version.isNotEmpty ? _version : '…'}'),
+            const SizedBox(height: 8),
+            const Text(
+              'Browse and manage your Hermes Agent sessions from your phone. '
+              'Connects to a Hermes dashboard running on your local network.',
+              style: TextStyle(color: Colors.grey),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -648,6 +648,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:
@@ -1069,6 +1085,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.15.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hermes_android
 description: "Hermes Agent — Multi-Session Chat via REST API"
 publish_to: 'none'
-version: 0.3.7+37
+version: 0.3.8+38
 
 environment:
   sdk: ^3.12.0
@@ -38,6 +38,7 @@ dependencies:
   image_picker: ^1.0.0
   file_selector: ^1.0.0
   flutter_local_notifications: ^18.0.0
+  package_info_plus: ^8.0.0
 
   # Markdown syntax highlighting
   highlight: ^0.7.0


### PR DESCRIPTION
### Version auto-read
- Settings now reads version from `package_info_plus` (from pubspec.yaml)
- Shows `0.3.8+38` instead of hardcoded `0.1.0`

### Tolerant resumeSession
- Chat screen catches 'session not found' on resume and continues
- Agent creates sessions implicitly on first prompt
- Failed WS session.create falls back to offline session with warning

### Fallback session creation
- If WS `session.create` fails, creates timestamp-based ID and navigates directly
- Orange snackbar warns that the session is offline