### PR TITLE
fix: Use session.create instead of session.resume (fixes session not found)

### DIFF
--- a/lib/core/screens/chat_screen.dart
+++ b/lib/core/screens/chat_screen.dart
@@ -231,9 +231,9 @@ class _ChatScreenState extends State<ChatScreen> {
     _ws ??= WsClient(widget.connection.baseUrl, token: _client != null ? await _client!.getToken(widget.connection.baseUrl) : null);
     await _ws!.connect();
 
-    // Resume the session — if this fails, propagate the error
-    // so the caller can show a meaningful message.
-    await _ws!.resumeSession(widget.session.id);
+    // Use session.create to start an agent for this session.
+    // session.resume only works for sessions already active in the gateway.
+    await _ws!.createOrResumeSession(widget.session.id);
 
     // Track streaming state
     _streamedContent = '';
@@ -340,7 +340,7 @@ class _ChatScreenState extends State<ChatScreen> {
   Future<void> _sendViaRest(String text) async {
     final ws = WsClient(widget.connection.baseUrl, token: _client != null ? await _client!.getToken(widget.connection.baseUrl) : null);
     await ws.connect();
-    await ws.resumeSession(widget.session.id);
+    await ws.createOrResumeSession(widget.session.id);
     await ws.sendMessage(text);
     ws.close();
 

--- a/lib/core/services/ws_client.dart
+++ b/lib/core/services/ws_client.dart
@@ -252,6 +252,19 @@ class WsClient {
     return result['result']?['session_id'] as String? ?? '';
   }
 
+  /// Resume an existing session via session.create (which starts a new
+  /// agent process for the given session ID). This works for sessions
+  /// that exist in the REST API but aren't active in the gateway.
+  Future<String> createOrResumeSession(String sessionId) async {
+    final result = await send('session.create', {'session_id': sessionId});
+    if (result['error'] != null) {
+      final errMap = result['error'] as Map<String, dynamic>;
+      final errorMsg = errMap['message'] as String?;
+      throw JsonRpcError('session.create', errorMsg ?? 'Unknown error');
+    }
+    return result['result']?['session_id'] as String? ?? sessionId;
+  }
+
   bool get isConnected => _connected;
 
   /// Close the connection.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hermes_android
 description: "Hermes Agent — Multi-Session Chat via REST API"
 publish_to: 'none'
-version: 0.3.9+39
+version: 0.3.10+40
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
### Root cause
`session.resume` only works for sessions currently active in the gateway process. Sessions from the REST API (created via CLI or previous gateway instances) aren't known to the current gateway, so `session.resume` returns "session not found".

### Fix
Use `session.create` with the `session_id` parameter instead. This starts a new agent process for the given session, whether it's new or existing. Added `createOrResumeSession()` to WsClient for this purpose.

### Affected
- All sessions (new and existing) — both were failing with "session not found"
- Both WS streaming path and REST fallback path