### PR TITLE
fix: repair chat streaming and cron requests

### DIFF
--- a/lib/core/screens/chat_screen.dart
+++ b/lib/core/screens/chat_screen.dart
@@ -159,6 +159,10 @@ class _ChatScreenState extends State<ChatScreen> {
           }
         });
       },
+      onToolProgress: (progress) {
+        if (!mounted) return;
+        _upsertToolProgress(progress);
+      },
       onDone: () async {
         if (!mounted) return;
         // Refresh messages to get the final server-side state
@@ -211,6 +215,48 @@ class _ChatScreenState extends State<ChatScreen> {
         ),
       );
     }
+  }
+
+  void _upsertToolProgress(Map<String, dynamic> progress) {
+    final toolCallId =
+        progress['toolCallId']?.toString() ??
+        progress['tool_call_id']?.toString() ??
+        progress['id']?.toString() ??
+        '';
+    final tool = progress['tool']?.toString() ?? 'tool';
+    final status = progress['status']?.toString() ?? 'running';
+    final emoji = progress['emoji']?.toString() ?? '🔧';
+    final label = progress['label']?.toString();
+    final display = label == null || label.isEmpty ? tool : label;
+    final done = status == 'completed' || status == 'finished';
+    final content = done
+        ? '$emoji $display — done'
+        : '$emoji $display — $status';
+
+    setState(() {
+      final idx = toolCallId.isEmpty
+          ? -1
+          : _messages.indexWhere(
+              (m) =>
+                  m['role'] == 'tool_progress' && m['toolCallId'] == toolCallId,
+            );
+      final payload = {
+        'role': 'tool_progress',
+        'content': content,
+        'toolCallId': toolCallId,
+        'status': status,
+        'tool': tool,
+      };
+      if (idx >= 0) {
+        _messages[idx] = payload;
+      } else {
+        final insertAt =
+            _messages.isNotEmpty && _messages[0]['role'] == 'assistant' ? 1 : 0;
+        _messages.insert(insertAt, payload);
+      }
+    });
+
+    WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToBottom());
   }
 
   @override

--- a/lib/core/screens/cron_screen.dart
+++ b/lib/core/screens/cron_screen.dart
@@ -197,7 +197,18 @@ class _CronScreenState extends State<CronScreen> {
     if (result == null || !mounted) return;
 
     try {
-      await _client.apiPost('cron/jobs', body: result);
+      final created = await _client.createJob(
+        name: result['name']?.toString() ?? '',
+        prompt: result['prompt']?.toString() ?? '',
+        schedule: result['schedule']?.toString() ?? '',
+      );
+      if (result['no_agent'] == true) {
+        final jobId =
+            created['id']?.toString() ?? created['job_id']?.toString() ?? '';
+        if (jobId.isNotEmpty) {
+          await _client.updateJob(jobId, {'no_agent': true});
+        }
+      }
       if (!mounted) return;
       ScaffoldMessenger.of(
         context,
@@ -230,7 +241,7 @@ class _CronScreenState extends State<CronScreen> {
     if (jobId.isEmpty) return;
 
     try {
-      await _client.apiPut('cron/jobs/$jobId', body: result);
+      await _client.updateJob(jobId, result);
       if (!mounted) return;
       ScaffoldMessenger.of(
         context,

--- a/lib/core/services/connection_manager.dart
+++ b/lib/core/services/connection_manager.dart
@@ -218,6 +218,8 @@ class ApiClient {
   void close() => _http.close();
 }
 
+typedef ToolProgressCallback = void Function(Map<String, dynamic> progress);
+
 /// SSE streaming chat client for the Gateway API Server.
 class GatewayChatClient {
   final ApiClient _api;
@@ -230,6 +232,84 @@ class GatewayChatClient {
     return 'mob-${DateTime.now().millisecondsSinceEpoch}-${const Uuid().v4()}';
   }
 
+  /// Build OpenAI chat-completions messages, preserving prior history and
+  /// ensuring the newly typed user message is present exactly once at the end.
+  static List<Map<String, dynamic>> buildChatCompletionMessages({
+    required String message,
+    List<Map<String, dynamic>>? history,
+  }) {
+    final messages = <Map<String, dynamic>>[];
+    if (history != null && history.isNotEmpty) {
+      for (final msg in history) {
+        final role = (msg['role'] == 'agent' || msg['role'] == 'assistant')
+            ? 'assistant'
+            : 'user';
+        final content = msg['content']?.toString() ?? '';
+        if (content.isEmpty) continue;
+        messages.add({'role': role, 'content': content});
+      }
+    }
+
+    final latest = message.trim();
+    final alreadyLast =
+        messages.isNotEmpty &&
+        messages.last['role'] == 'user' &&
+        messages.last['content'] == latest;
+    if (latest.isNotEmpty && !alreadyLast) {
+      messages.add({'role': 'user', 'content': latest});
+    }
+    return messages;
+  }
+
+  /// Parse one SSE frame. Returns streamed text token, or null for non-token
+  /// frames. Hermes tool progress frames are delivered via [onToolProgress].
+  static String? parseSseFrame(
+    String frame, {
+    ToolProgressCallback? onToolProgress,
+  }) {
+    String eventType = '';
+    final dataLines = <String>[];
+
+    for (final rawLine in frame.split('\n')) {
+      final line = rawLine.trimRight();
+      if (line.isEmpty || line.startsWith(':')) continue;
+      if (line.startsWith('event:')) {
+        eventType = line.substring(6).trim();
+      } else if (line.startsWith('data:')) {
+        dataLines.add(line.substring(5).trimLeft());
+      }
+    }
+
+    if (dataLines.isEmpty) return null;
+    final data = dataLines.join('\n').trim();
+    if (data.isEmpty || data == '[DONE]') return null;
+
+    try {
+      final parsed = jsonDecode(data);
+      if (eventType == 'hermes.tool.progress') {
+        if (parsed is Map<String, dynamic>) onToolProgress?.call(parsed);
+        return null;
+      }
+
+      if (parsed is Map<String, dynamic>) {
+        final choices = parsed['choices'] as List?;
+        if (choices != null && choices.isNotEmpty && choices.first is Map) {
+          final first = choices.first as Map;
+          final delta = first['delta'];
+          if (delta is Map) {
+            final content = delta['content'];
+            if (content != null && content.toString().isNotEmpty) {
+              return content.toString();
+            }
+          }
+        }
+      }
+    } catch (_) {
+      return null;
+    }
+    return null;
+  }
+
   /// Send a message and stream the assistant response token-by-token.
   Future<void> sendMessageStreaming({
     required String message,
@@ -237,22 +317,14 @@ class GatewayChatClient {
     String? model,
     List<Map<String, dynamic>>? history,
     required void Function(String token) onToken,
+    ToolProgressCallback? onToolProgress,
     required void Function() onDone,
     required void Function(String error) onError,
   }) async {
-    final messages = <Map<String, dynamic>>[];
-    if (history != null && history.isNotEmpty) {
-      for (final msg in history) {
-        final role = (msg['role'] == 'agent' || msg['role'] == 'assistant')
-            ? 'assistant'
-            : 'user';
-        messages.add({'role': role, 'content': msg['content'] ?? ''});
-      }
-    } else {
-      // Only add the user message if history is null/empty
-      // (when history is provided, the user message is already the last entry)
-      messages.add({'role': 'user', 'content': message});
-    }
+    final messages = buildChatCompletionMessages(
+      message: message,
+      history: history,
+    );
 
     final body = {
       'model': model ?? 'hermes-agent',
@@ -293,29 +365,11 @@ class GatewayChatClient {
         buffer += chunk;
         while (buffer.contains('\n\n')) {
           final eventEnd = buffer.indexOf('\n\n');
-          final event = buffer.substring(0, eventEnd);
+          final frame = buffer.substring(0, eventEnd);
           buffer = buffer.substring(eventEnd + 2);
 
-          for (final line in event.split('\n')) {
-            if (line.startsWith('data: ')) {
-              final data = line.substring(6).trim();
-              if (data == '[DONE]') continue;
-
-              try {
-                final parsed = jsonDecode(data);
-                final choices = parsed['choices'] as List?;
-                if (choices != null && choices.isNotEmpty) {
-                  final delta = choices[0]['delta'];
-                  if (delta != null) {
-                    final content = delta['content'];
-                    if (content != null && content.toString().isNotEmpty) {
-                      onToken(content.toString());
-                    }
-                  }
-                }
-              } catch (_) {}
-            }
-          }
+          final token = parseSseFrame(frame, onToolProgress: onToolProgress);
+          if (token != null && token.isNotEmpty) onToken(token);
         }
       });
 
@@ -497,6 +551,10 @@ class DashboardClient {
     },
   );
 
+  static Map<String, dynamic> buildCronUpdateBody(
+    Map<String, dynamic> updates,
+  ) => {'updates': updates};
+
   Future<Map<String, dynamic>> updateJob(
     String jobId,
     Map<String, dynamic> updates,
@@ -505,7 +563,7 @@ class DashboardClient {
     final res = await _http.put(
       Uri.parse('$_baseUrl/api/cron/jobs/$jobId'),
       headers: headers,
-      body: jsonEncode({'updates': updates}),
+      body: jsonEncode(buildCronUpdateBody(updates)),
     );
     if (res.statusCode == 401) {
       _token = null;

--- a/test/connection_manager_test.dart
+++ b/test/connection_manager_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hermes_android/core/services/connection_manager.dart';
+
+void main() {
+  group('GatewayChatClient', () {
+    test('appends latest user message to existing history exactly once', () {
+      final messages = GatewayChatClient.buildChatCompletionMessages(
+        message: 'new question',
+        history: [
+          {'role': 'user', 'content': 'old question'},
+          {'role': 'assistant', 'content': 'old answer'},
+        ],
+      );
+
+      expect(messages, [
+        {'role': 'user', 'content': 'old question'},
+        {'role': 'assistant', 'content': 'old answer'},
+        {'role': 'user', 'content': 'new question'},
+      ]);
+    });
+
+    test(
+      'does not duplicate latest user message already present in history',
+      () {
+        final messages = GatewayChatClient.buildChatCompletionMessages(
+          message: 'new question',
+          history: [
+            {'role': 'user', 'content': 'old question'},
+            {'role': 'assistant', 'content': 'old answer'},
+            {'role': 'user', 'content': 'new question'},
+          ],
+        );
+
+        expect(
+          messages.where((m) => m['content'] == 'new question'),
+          hasLength(1),
+        );
+        expect(messages.last, {'role': 'user', 'content': 'new question'});
+      },
+    );
+
+    test('parses normal chat completion SSE token frames', () {
+      final token = GatewayChatClient.parseSseFrame(
+        'data: {"choices":[{"delta":{"content":"hello"}}]}',
+      );
+
+      expect(token, 'hello');
+    });
+
+    test('parses Hermes tool progress SSE frames via callback', () {
+      Map<String, dynamic>? progress;
+      final token = GatewayChatClient.parseSseFrame(
+        'event: hermes.tool.progress\n'
+        'data: {"tool":"read_file","toolCallId":"call_1","status":"running"}',
+        onToolProgress: (p) => progress = p,
+      );
+
+      expect(token, isNull);
+      expect(progress, isNotNull);
+      expect(progress!['tool'], 'read_file');
+      expect(progress!['toolCallId'], 'call_1');
+      expect(progress!['status'], 'running');
+    });
+  });
+
+  group('DashboardClient', () {
+    test('wraps cron job updates for dashboard endpoint', () {
+      final updates = {'name': 'Daily', 'no_agent': true};
+
+      expect(DashboardClient.buildCronUpdateBody(updates), {
+        'updates': updates,
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary\n- Ensure chat completions include the latest user message exactly once when history exists\n- Parse Hermes named SSE tool progress events and surface them in chat during streaming\n- Send cron job edits through the dashboard {updates: ...} wrapper\n- Send accepted create fields first, then apply no-agent via update when requested\n- Add regression tests for chat message building, SSE parsing, and cron update payloads\n\nCloses #54\nCloses #55\n\n## Test plan\n- flutter analyze\n- flutter test\n- flutter build apk --release --split-per-abi