### PR TITLE
fix: omit default ports from baseUrl to avoid proxy issues

### DIFF
--- a/lib/core/models/connection.dart
+++ b/lib/core/models/connection.dart
@@ -30,6 +30,10 @@ class SavedConnection {
 
   String get baseUrl {
     final scheme = useHttps ? 'https' : 'http';
+    final defaultPort = useHttps ? 443 : 80;
+    if (port == defaultPort) {
+      return '$scheme://$host';
+    }
     return '$scheme://$host:$port';
   }
 

--- a/lib/core/services/connection_manager.dart
+++ b/lib/core/services/connection_manager.dart
@@ -413,8 +413,17 @@ class DashboardClient {
     required String host,
     int port = 9119,
     bool useHttps = false,
-  }) : _baseUrl = '${useHttps ? 'https' : 'http'}://$host:$port',
+  }) : _baseUrl = _buildBaseUrl(host, port, useHttps),
        _http = http.Client();
+
+  static String _buildBaseUrl(String host, int port, bool useHttps) {
+    final scheme = useHttps ? 'https' : 'http';
+    final defaultPort = useHttps ? 443 : 80;
+    if (port == defaultPort) {
+      return '$scheme://$host';
+    }
+    return '$scheme://$host:$port';
+  }
 
   Future<String> _getToken() async {
     if (_token != null) return _token!;

--- a/test/connection_manager_test.dart
+++ b/test/connection_manager_test.dart
@@ -94,7 +94,7 @@ void main() {
           port: conn.dashboardPort,
           useHttps: conn.useHttps,
         ).baseUrl,
-        'https://hermes.example.com:443',
+        'https://hermes.example.com',
       );
     });
   });


### PR DESCRIPTION
## Problem

The merged HTTPS support (v1.0.4) generates base URLs with explicit default ports. For example, when a user enters `https://f4b404-hermes.hf.space` with port 443, the app produces `https://f4b404-hermes.hf.space:443`.

The Dart http package sends the explicit port in the Host header (e.g. `Host: f4b404-hermes.hf.space:443`). Some reverse proxies (HF Spaces / Cloudflare) do not expect the default port in the Host header and may return 401 or 404.

## Fix

Omit the port from the URL when it matches the scheme default:
- `https://host` instead of `https://host:443`
- `http://host` instead of `http://host:80`

Custom non-default ports (e.g. 8443, 8080, 9119) are still included.

## Files changed

| File | Change |
|------|--------|
| `lib/core/models/connection.dart` | `baseUrl` omits default ports |
| `lib/core/services/connection_manager.dart` | `DashboardClient._buildBaseUrl` omits default ports |

## Backward compatibility

HTTP localhost connections still work. Custom ports still work.
