### PR TITLE
feat: add voice support (speech-to-text input, text-to-speech output)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
         android:label="Hermes Agent"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -49,6 +49,8 @@
 	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Hermes needs microphone access for voice input when sending messages.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/lib/core/screens/chat_screen.dart
+++ b/lib/core/screens/chat_screen.dart
@@ -1,11 +1,14 @@
 // Chat screen with real-time streaming via REST API.
 // Uses REST endpoints: POST /api/sessions/{id}/chat and
 // GET /api/sessions/{id}/messages.
+// Voice support: speech-to-text input via microphone button,
+// text-to-speech read-aloud on assistant messages.
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../services/connection_manager.dart';
+import '../services/voice_service.dart';
 import '../utils/responsive.dart';
 
 class ChatScreen extends StatefulWidget {
@@ -37,6 +40,9 @@ class _ChatScreenState extends State<ChatScreen> {
   // Verbose mode
   bool _verboseMode = false;
 
+  // Voice service
+  final VoiceService _voice = VoiceService();
+
   // Scroll management
   final _scrollController = ScrollController();
   bool _showScrollToBottom = false;
@@ -52,20 +58,45 @@ class _ChatScreenState extends State<ChatScreen> {
     _fetchMessages();
     _loadVerboseMode();
     _scrollController.addListener(_onScroll);
+    _initVoice();
   }
 
-  Future<void> _loadVerboseMode() async {
-    final prefs = await SharedPreferences.getInstance();
-    setState(() => _verboseMode = prefs.getBool('verbose_mode') ?? false);
+  Future<void> _initVoice() async {
+    _voice.onSpeechResult = (text) {
+      if (!mounted) return;
+      _textController.text = text;
+      _sendMessage();
+    };
+    _voice.onSpeechInterim = (text) {
+      if (!mounted) return;
+      setState(() {
+        // Interim text shown in the input field
+        if (_textController.text != text) {
+          _textController.text = text;
+        }
+      });
+    };
+    _voice.addListener(_onVoiceChange);
+  }
+
+  void _onVoiceChange() {
+    if (mounted) setState(() {});
   }
 
   @override
   void dispose() {
+    _voice.removeListener(_onVoiceChange);
+    _voice.dispose();
     _client.close();
     _textController.dispose();
     _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
     super.dispose();
+  }
+
+  Future<void> _loadVerboseMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    setState(() => _verboseMode = prefs.getBool('verbose_mode') ?? false);
   }
 
   void _onScroll() {
@@ -312,6 +343,9 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   Widget _buildInputBar() {
+    final listening = _voice.isListening;
+    final hasStt = _voice.sttAvailable && _voice.sttEnabled;
+
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
       decoration: BoxDecoration(
@@ -321,44 +355,102 @@ class _ChatScreenState extends State<ChatScreen> {
         ],
       ),
       child: SafeArea(
-        child: Row(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
           children: [
-            Expanded(
-              child: TextField(
-                controller: _textController,
-                decoration: InputDecoration(
-                  hintText: 'Type a message…',
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(24),
-                  ),
-                  contentPadding: const EdgeInsets.symmetric(
-                    horizontal: 16,
-                    vertical: 8,
-                  ),
-                  isDense: true,
-                ),
-                minLines: 1,
-                maxLines: 4,
-                textCapitalization: TextCapitalization.sentences,
-                keyboardType: TextInputType.multiline,
-                textInputAction: TextInputAction.send,
-                enabled: !_loading && !_streaming,
-                onSubmitted: (_) => _sendMessage(),
-              ),
-            ),
-            const SizedBox(width: 8),
-            CircleAvatar(
-              child: _streaming
-                  ? const SizedBox(
-                      width: 20,
-                      height: 20,
+            // Interim recognition display
+            if (listening)
+              Container(
+                width: double.infinity,
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                child: Row(
+                  children: [
+                    const SizedBox(
+                      width: 12,
+                      height: 12,
                       child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : IconButton(
-                      icon: const Icon(Icons.send, size: 20),
-                      onPressed: _sendMessage,
-                      tooltip: 'Send',
                     ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        _voice.lastRecognizedWords.isEmpty
+                            ? 'Listening…'
+                            : _voice.lastRecognizedWords,
+                        style: TextStyle(
+                          fontStyle: _voice.lastRecognizedWords.isEmpty
+                              ? FontStyle.italic
+                              : FontStyle.normal,
+                          color: Colors.grey[600],
+                          fontSize: 13,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            Row(
+              children: [
+                // Microphone button
+                if (hasStt)
+                  IconButton(
+                    icon: Icon(
+                      listening ? Icons.mic : Icons.mic_none,
+                      color: listening ? Colors.red : null,
+                    ),
+                    tooltip: listening ? 'Stop listening' : 'Voice input',
+                    onPressed: (_loading || _streaming)
+                        ? null
+                        : () {
+                            if (listening) {
+                              _voice.stopListening();
+                            } else {
+                              _voice.startListening();
+                            }
+                          },
+                  ),
+                Expanded(
+                  child: TextField(
+                    controller: _textController,
+                    decoration: InputDecoration(
+                      hintText: listening
+                          ? 'Speak now…'
+                          : 'Type a message…',
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(24),
+                      ),
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 8,
+                      ),
+                      isDense: true,
+                    ),
+                    minLines: 1,
+                    maxLines: 4,
+                    textCapitalization: TextCapitalization.sentences,
+                    keyboardType: TextInputType.multiline,
+                    textInputAction: TextInputAction.send,
+                    enabled: !_loading && !_streaming && !listening,
+                    onSubmitted: (_) => _sendMessage(),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                CircleAvatar(
+                  child: _streaming
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : IconButton(
+                          icon: const Icon(Icons.send, size: 20),
+                          onPressed: _sendMessage,
+                          tooltip: 'Send',
+                        ),
+                ),
+              ],
             ),
           ],
         ),
@@ -416,6 +508,8 @@ class _ChatScreenState extends State<ChatScreen> {
           isUser: isUser,
           verbose: _verboseMode,
           metadata: msg,
+          ttsEnabled: _voice.ttsEnabled,
+          onReadAloud: (text) => _voice.speak(text),
         );
       },
     );
@@ -427,12 +521,16 @@ class _MessageBubble extends StatelessWidget {
   final bool isUser;
   final bool verbose;
   final Map<String, dynamic> metadata;
+  final bool ttsEnabled;
+  final void Function(String text)? onReadAloud;
 
   const _MessageBubble({
     required this.content,
     required this.isUser,
     this.verbose = false,
     this.metadata = const {},
+    this.ttsEnabled = false,
+    this.onReadAloud,
   });
 
   @override
@@ -574,8 +672,26 @@ class _MessageBubble extends StatelessWidget {
       mainAxisAlignment: isUser
           ? MainAxisAlignment.end
           : MainAxisAlignment.start,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [bubble],
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        bubble,
+        // TTS read-aloud button on assistant messages
+        if (!isUser && ttsEnabled && onReadAloud != null && content.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(left: 4),
+            child: IconButton(
+              icon: const Icon(Icons.volume_up, size: 18),
+              onPressed: () => onReadAloud!(content),
+              tooltip: 'Read aloud',
+              visualDensity: VisualDensity.compact,
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(
+                minWidth: 32,
+                minHeight: 32,
+              ),
+            ),
+          ),
+      ],
     );
   }
 }

--- a/lib/core/screens/settings_screen.dart
+++ b/lib/core/screens/settings_screen.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../services/connection_manager.dart';
+import '../services/voice_service.dart';
 import '../../main.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
@@ -310,6 +311,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
         _VerboseToggle(),
         const SizedBox(height: 16),
 
+        // ---- Section: Voice ----
+        _buildSectionHeader('Voice'),
+        _VoiceSettingsToggle(),
+        const SizedBox(height: 16),
+
         // ---- Section: Connection ----
         _buildSectionHeader('Connection'),
         Card(
@@ -535,6 +541,116 @@ class _ThemeToggleState extends State<_ThemeToggle> {
         onSelectionChanged: (s) => _setMode(s.first),
         style: ButtonStyle(visualDensity: VisualDensity.compact),
       ),
+    );
+  }
+}
+
+/// Voice settings toggle for speech-to-text and text-to-speech.
+class _VoiceSettingsToggle extends StatefulWidget {
+  @override
+  State<_VoiceSettingsToggle> createState() => _VoiceSettingsToggleState();
+}
+
+class _VoiceSettingsToggleState extends State<_VoiceSettingsToggle> {
+  final VoiceService _voice = VoiceService();
+  bool _sttEnabled = true;
+  bool _ttsEnabled = true;
+  double _ttsRate = 0.5;
+
+  @override
+  void initState() {
+    super.initState();
+    _sttEnabled = _voice.sttEnabled;
+    _ttsEnabled = _voice.ttsEnabled;
+    _ttsRate = _voice.ttsRate;
+    _voice.addListener(_onChange);
+  }
+
+  @override
+  void dispose() {
+    _voice.removeListener(_onChange);
+    _voice.dispose();
+    super.dispose();
+  }
+
+  void _onChange() {
+    if (mounted) {
+      setState(() {
+        _sttEnabled = _voice.sttEnabled;
+        _ttsEnabled = _voice.ttsEnabled;
+        _ttsRate = _voice.ttsRate;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Card(
+          child: SwitchListTile(
+            title: const Text('Speech-to-Text'),
+            subtitle: const Text(
+                'Use your voice to send messages (microphone required)'),
+            secondary: const Icon(Icons.mic),
+            value: _sttEnabled,
+            onChanged: (v) => _voice.setSttEnabled(v),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Card(
+          child: SwitchListTile(
+            title: const Text('Text-to-Speech'),
+            subtitle:
+                const Text('Read Hermes responses aloud (speaker icon in chat)'),
+            secondary: const Icon(Icons.record_voice_over),
+            value: _ttsEnabled,
+            onChanged: (v) => _voice.setTtsEnabled(v),
+          ),
+        ),
+        if (_ttsEnabled) ...[
+          const SizedBox(height: 8),
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+              child: Row(
+                children: [
+                  const Icon(Icons.speed),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Text('Speech Rate',
+                            style: TextStyle(fontSize: 15)),
+                        Text(
+                          '${(_ttsRate * 2).toStringAsFixed(1)}x',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: Colors.grey[600],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    flex: 2,
+                    child: Slider(
+                      value: _ttsRate,
+                      min: 0.1,
+                      max: 1.0,
+                      divisions: 9,
+                      label: '${(_ttsRate * 2).toStringAsFixed(1)}x',
+                      onChanged: (v) => _voice.setTtsRate(v),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ],
     );
   }
 }

--- a/lib/core/services/voice_service.dart
+++ b/lib/core/services/voice_service.dart
@@ -1,0 +1,161 @@
+// Voice service for speech-to-text input and text-to-speech output.
+// Uses speech_to_text for STT and flutter_tts for TTS.
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:speech_to_text/speech_to_text.dart' as stt;
+import 'package:flutter_tts/flutter_tts.dart';
+
+/// Manages speech-to-text and text-to-speech for the Hermes chat UI.
+class VoiceService extends ChangeNotifier {
+  final stt.SpeechToText _speech = stt.SpeechToText();
+  final FlutterTts _tts = FlutterTts();
+
+  bool _sttAvailable = false;
+  bool _isListening = false;
+  bool _ttsEnabled = true;
+  bool _sttEnabled = true;
+  String _lastRecognizedWords = '';
+  double _ttsRate = 0.5;
+
+  bool get sttAvailable => _sttAvailable;
+  bool get isListening => _isListening;
+  bool get ttsEnabled => _ttsEnabled;
+  bool get sttEnabled => _sttEnabled;
+  String get lastRecognizedWords => _lastRecognizedWords;
+  double get ttsRate => _ttsRate;
+
+  /// Callback invoked when speech is recognised (final result).
+  void Function(String text)? onSpeechResult;
+
+  /// Callback invoked with interim recognition.
+  void Function(String text)? onSpeechInterim;
+
+  VoiceService() {
+    _init();
+  }
+
+  Future<void> _init() async {
+    // Initialise STT
+    _sttAvailable = await _speech.initialize(
+      onError: (_) => _sttAvailable = false,
+      onStatus: (status) {
+        if (status == 'done' || status == 'notListening') {
+          _isListening = false;
+          notifyListeners();
+        }
+      },
+    );
+
+    // Initialise TTS
+    await _tts.setLanguage('en-US');
+    await _tts.setSpeechRate(_ttsRate);
+    await _tts.setPitch(1.0);
+    await _tts.setVolume(1.0);
+    await _tts.awaitSpeakCompletion(true);
+
+    // Load preferences
+    final prefs = await SharedPreferences.getInstance();
+    _ttsEnabled = prefs.getBool('voice_tts_enabled') ?? true;
+    _sttEnabled = prefs.getBool('voice_stt_enabled') ?? true;
+    _ttsRate = prefs.getDouble('voice_tts_rate') ?? 0.5;
+
+    notifyListeners();
+  }
+
+  // ── Speech-to-Text ─────────────────────────────────────────────────
+
+  /// Start listening for speech. Results are delivered via [onSpeechResult].
+  Future<bool> startListening() async {
+    if (!_sttAvailable || _isListening) return false;
+
+    _lastRecognizedWords = '';
+    _isListening = true;
+    notifyListeners();
+
+    await _speech.listen(
+      onResult: (result) {
+        _lastRecognizedWords = result.recognizedWords;
+        if (result.finalResult) {
+          _isListening = false;
+          notifyListeners();
+          if (_lastRecognizedWords.isNotEmpty) {
+            onSpeechResult?.call(_lastRecognizedWords);
+          }
+        } else {
+          onSpeechInterim?.call(result.recognizedWords);
+          notifyListeners();
+        }
+      },
+      listenFor: const Duration(seconds: 30),
+      pauseFor: const Duration(seconds: 3),
+      partialResults: true,
+      localeId: 'en_US',
+      cancelOnError: true,
+      listenMode: stt.ListenMode.confirmation,
+    );
+
+    return true;
+  }
+
+  /// Stop listening and return any recognised text.
+  Future<void> stopListening() async {
+    if (!_isListening) return;
+    await _speech.stop();
+    _isListening = false;
+    notifyListeners();
+  }
+
+  /// Cancel listening without returning results.
+  Future<void> cancelListening() async {
+    if (!_isListening) return;
+    await _speech.cancel();
+    _isListening = false;
+    _lastRecognizedWords = '';
+    notifyListeners();
+  }
+
+  // ── Text-to-Speech ─────────────────────────────────────────────────
+
+  /// Speak the given text aloud using TTS.
+  Future<void> speak(String text) async {
+    if (!_ttsEnabled || text.trim().isEmpty) return;
+    await _tts.speak(text);
+  }
+
+  /// Stop any currently-playing TTS.
+  Future<void> stopSpeaking() async {
+    await _tts.stop();
+  }
+
+  // ── Preferences ────────────────────────────────────────────────────
+
+  Future<void> setTtsEnabled(bool value) async {
+    _ttsEnabled = value;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('voice_tts_enabled', value);
+    if (!value) await stopSpeaking();
+    notifyListeners();
+  }
+
+  Future<void> setSttEnabled(bool value) async {
+    _sttEnabled = value;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('voice_stt_enabled', value);
+    notifyListeners();
+  }
+
+  Future<void> setTtsRate(double value) async {
+    _ttsRate = value;
+    await _tts.setSpeechRate(value);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble('voice_tts_rate', value);
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _speech.cancel();
+    _tts.stop();
+    super.dispose();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hermes_android
 description: "Hermes Agent — chat with your Hermes Gateway API Server over LAN. SSE streaming, Bearer auth, session management."
 publish_to: 'none'
-version: 1.0.5+105
+version: 1.0.6+106
 
 environment:
   sdk: ^3.12.0
@@ -32,6 +32,10 @@ dependencies:
   # Data models
   json_annotation: ^4.9.0
   uuid: ^4.5.1
+
+  # Voice
+  speech_to_text: ^7.3.0
+  flutter_tts: ^4.4.1
 
   # Misc
   url_launcher: ^6.3.0


### PR DESCRIPTION
## Summary

Adds voice interaction support to the Hermes Android app.

### Speech-to-Text (Voice Input)
- Microphone button in the chat input bar
- Tap to start listening, speak your message, and it auto-sends when you finish
- Interim speech recognition shown in real-time above the input field
- Requires microphone permission (prompted on first use)

### Text-to-Speech (Read Aloud)
- Speaker icon on each assistant message bubble
- Tap to have Hermes's response read aloud via TTS
- Configurable speech rate in Settings

### Settings
- Voice section added to Settings with:
  - Speech-to-Text enable/disable toggle
  - Text-to-Speech enable/disable toggle  
  - Speech rate slider (0.2x to 2.0x)

### Technical
- Uses speech_to_text (^7.3.0) for STT
- Uses flutter_tts (^4.4.1) for TTS  
- RECORD_AUDIO permission on Android
- NSMicrophoneUsageDescription on iOS
- VoiceService (ChangeNotifier) for shared voice state
- All preferences persisted via SharedPreferences

Closes #59