### PR TITLE
fix(chat): use session API streaming endpoint to persist history

### DIFF
--- a/lib/core/screens/chat_screen.dart
+++ b/lib/core/screens/chat_screen.dart
@@ -250,11 +250,10 @@ class _ChatScreenState extends State<ChatScreen> {
     _awaitingVoiceReply = speakResponse && _voiceReplyEnabled;
 
     // Build conversation history for SSE request
-    final history = <Map<String, dynamic>>[];
-    for (var i = _messages.length - 1; i >= 0; i--) {
-      final m = _messages[i];
-      history.add({'role': m['role'] ?? 'user', 'content': m['content'] ?? ''});
-    }
+    // Note: kept for potential future use (e.g. fallback to /v1/chat/completions)
+    // but not passed to sendMessageStreamingViaSessionApi, which loads history
+    // server-side from the session row.
+    // final history = ...
 
     setState(() {
       _sending = true;
@@ -267,11 +266,12 @@ class _ChatScreenState extends State<ChatScreen> {
 
     WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToBottom());
 
-    // Accumulate tokens into the streaming placeholder
-    await _gateway.sendMessageStreaming(
+    // Use the session-native streaming endpoint so history is persisted to the
+    // correct session row. On run.completed the server delivers the authoritative
+    // turn messages in the SSE event itself -- no separate GET /messages needed.
+    await _gateway.sendMessageStreamingViaSessionApi(
       message: text,
       sessionId: widget.session.id,
-      history: history,
       onToken: (token) {
         if (!mounted) return;
         setState(() {
@@ -285,36 +285,31 @@ class _ChatScreenState extends State<ChatScreen> {
         if (!mounted) return;
         _upsertToolProgress(progress);
       },
-      onDone: () async {
+      onCompleted: (serverMessages) async {
         if (!mounted) return;
-        // Refresh messages to get the final server-side state
-        try {
-          final messages = await _client.getMessages(widget.session.id);
-          if (!mounted) return;
-          setState(() {
-            _messages = messages;
-            _streaming = false;
-            _sending = false;
-            _showScrollToBottom = false;
-          });
-          if (_awaitingVoiceReply) {
-            _awaitingVoiceReply = false;
-            final assistant = messages.reversed.firstWhere(
-              (message) => message['role'] == 'assistant',
-              orElse: () => const <String, dynamic>{},
-            );
-            final assistantText = assistant['content']?.toString();
-            if (assistantText != null) {
-              await _speakAssistantText(assistantText);
-            }
+        // Use the authoritative turn messages from the run.completed event when
+        // available; fall back to the optimistically-rendered local state so the
+        // UI is never left empty even on older server versions.
+        final messages =
+            serverMessages.isNotEmpty ? serverMessages : List<Map<String, dynamic>>.from(_messages);
+        setState(() {
+          _messages = messages;
+          _streaming = false;
+          _sending = false;
+          _showScrollToBottom = false;
+        });
+        if (_awaitingVoiceReply) {
+          _awaitingVoiceReply = false;
+          final assistant = messages.reversed.firstWhere(
+            (message) => message['role'] == 'assistant',
+            orElse: () => const <String, dynamic>{},
+          );
+          final assistantText = assistant['content']?.toString();
+          if (assistantText != null) {
+            await _speakAssistantText(assistantText);
           }
-          _scrollToBottom();
-        } catch (e) {
-          setState(() {
-            _streaming = false;
-            _sending = false;
-          });
         }
+        _scrollToBottom();
       },
       onError: (error) {
         if (!mounted) return;

--- a/lib/core/services/connection_manager.dart
+++ b/lib/core/services/connection_manager.dart
@@ -325,6 +325,16 @@ class GatewayChatClient {
   }
 
   /// Send a message and stream the assistant response token-by-token.
+  ///
+  /// Uses `POST /v1/chat/completions` (stateless OpenAI-compat endpoint).
+  /// History is sent in the request body; the session is identified by
+  /// [sessionId] via the `X-Hermes-Session-Id` header.
+  ///
+  /// NOTE: prefer [sendMessageStreamingViaSessionApi] for sessions that are
+  /// managed through the session browser. That endpoint persists history to
+  /// the correct session row and delivers the final messages in the
+  /// `run.completed` event, avoiding the separate `GET /messages` round-trip
+  /// that this method requires on `onDone`.
   Future<void> sendMessageStreaming({
     required String message,
     required String sessionId,
@@ -390,6 +400,155 @@ class GatewayChatClient {
       onDone();
     } catch (e) {
       onError(e.toString());
+    }
+  }
+
+  /// Send a message via the session-native streaming endpoint.
+  ///
+  /// Posts to `POST /api/sessions/{sessionId}/chat/stream`. Unlike
+  /// [sendMessageStreaming], this endpoint:
+  ///
+  /// - Loads history from the correct session row before the agent run
+  /// - Persists the full conversation back to the same session row after
+  /// - Emits a `run.completed` SSE event with the authoritative turn messages,
+  ///   delivered to [onCompleted] so the caller never needs a separate
+  ///   `GET /messages` round-trip
+  ///
+  /// SSE event schema (Hermes API server v0.16.0+):
+  ///   `assistant.delta`  -- {delta: String}          streamed tokens
+  ///   `tool.started`     -- {tool_name, preview}      tool progress start
+  ///   `tool.completed`   -- {tool_name}               tool progress done
+  ///   `run.completed`    -- {messages: List}           final turn messages
+  ///   `error`            -- {message: String}          agent error
+  ///   `done`             -- (empty)                    stream closed
+  Future<void> sendMessageStreamingViaSessionApi({
+    required String message,
+    required String sessionId,
+    required void Function(String token) onToken,
+    ToolProgressCallback? onToolProgress,
+    required void Function(List<Map<String, dynamic>> messages) onCompleted,
+    required void Function(String error) onError,
+  }) async {
+    final body = {'message': message};
+
+    try {
+      final request = http.Request(
+        'POST',
+        Uri.parse('$_baseUrl/api/sessions/$sessionId/chat/stream'),
+      );
+      request.headers.addAll(_api._headers);
+      request.body = jsonEncode(body);
+
+      final response = await _api._http.send(request);
+
+      if (response.statusCode != 200) {
+        final errorBody = await response.stream.bytesToString();
+        String errorMsg;
+        try {
+          final err = jsonDecode(errorBody);
+          errorMsg =
+              err['error']?['message'] ??
+              err['message'] ??
+              'HTTP ${response.statusCode}';
+        } catch (_) {
+          errorMsg = 'HTTP ${response.statusCode}';
+        }
+        onError(errorMsg);
+        return;
+      }
+
+      List<Map<String, dynamic>> completedMessages = [];
+
+      String buffer = '';
+      await response.stream.transform(utf8.decoder).forEach((chunk) {
+        buffer += chunk;
+        while (buffer.contains('\n\n')) {
+          final eventEnd = buffer.indexOf('\n\n');
+          final frame = buffer.substring(0, eventEnd);
+          buffer = buffer.substring(eventEnd + 2);
+
+          _parseSessionSseFrame(
+            frame,
+            onToken: onToken,
+            onToolProgress: onToolProgress,
+            onRunCompleted: (msgs) => completedMessages = msgs,
+          );
+        }
+      });
+
+      onCompleted(completedMessages);
+    } catch (e) {
+      onError(e.toString());
+    }
+  }
+
+  /// Parse one SSE frame from the session chat stream endpoint.
+  ///
+  /// Dispatches to the appropriate callback based on the `event:` field:
+  ///   `assistant.delta`  -> [onToken]
+  ///   `tool.started`     -> [onToolProgress] with status 'running'
+  ///   `tool.completed`   -> [onToolProgress] with status 'completed'
+  ///   `run.completed`    -> [onRunCompleted] with the messages list
+  ///   `error`            -> throws so the caller's catch surfaces it
+  static void _parseSessionSseFrame(
+    String frame, {
+    required void Function(String token) onToken,
+    ToolProgressCallback? onToolProgress,
+    required void Function(List<Map<String, dynamic>> messages) onRunCompleted,
+  }) {
+    String eventType = '';
+    final dataLines = <String>[];
+
+    for (final rawLine in frame.split('\n')) {
+      final line = rawLine.trimRight();
+      if (line.isEmpty || line.startsWith(':')) continue;
+      if (line.startsWith('event:')) {
+        eventType = line.substring(6).trim();
+      } else if (line.startsWith('data:')) {
+        dataLines.add(line.substring(5).trimLeft());
+      }
+    }
+
+    if (dataLines.isEmpty) return;
+    final data = dataLines.join('\n').trim();
+    if (data.isEmpty) return;
+
+    Map<String, dynamic> parsed;
+    try {
+      parsed = jsonDecode(data) as Map<String, dynamic>;
+    } catch (_) {
+      return;
+    }
+
+    switch (eventType) {
+      case 'assistant.delta':
+        final delta = parsed['delta']?.toString() ?? '';
+        if (delta.isNotEmpty) onToken(delta);
+
+      case 'tool.started':
+        onToolProgress?.call({
+          'tool': parsed['tool_name']?.toString() ?? 'tool',
+          'toolCallId': parsed['message_id']?.toString() ?? '',
+          'label': parsed['preview']?.toString(),
+          'status': 'running',
+          'emoji': '\u{1F527}',
+        });
+
+      case 'tool.completed':
+        onToolProgress?.call({
+          'tool': parsed['tool_name']?.toString() ?? 'tool',
+          'toolCallId': parsed['message_id']?.toString() ?? '',
+          'status': 'completed',
+        });
+
+      case 'run.completed':
+        final raw = parsed['messages'];
+        if (raw is List) {
+          onRunCompleted(raw.whereType<Map<String, dynamic>>().toList());
+        }
+
+      case 'error':
+        throw Exception(parsed['message']?.toString() ?? 'Agent error');
     }
   }
 


### PR DESCRIPTION
chat_screen was calling POST /v1/chat/completions (stateless) with a session ID in X-Hermes-Session-Id. The server saved the conversation under that ID, but onDone then fetched GET /api/sessions/{id}/messages where id came from the session browser -- a different row. The GET returned empty, causing messages to vanish within ~1s of streaming.

Fix: switch to POST /api/sessions/{id}/chat/stream, the purpose-built session endpoint that:
- loads history from the correct session row before the agent run
- persists the full conversation back to the same session row after
- delivers the authoritative turn messages in the run.completed SSE event, eliminating the separate GET /messages round-trip entirely

Adds GatewayChatClient.sendMessageStreamingViaSessionApi() that parses the structured session SSE event schema (assistant.delta, tool.started, tool.completed, run.completed) and a static _parseSessionSseFrame() helper for the new event format.

The existing sendMessageStreaming() is kept unchanged with a deprecation note so it can still be used when a session API is unavailable.

Closes #65