### PR TITLE
feat: support password-protected dashboards and configurable dashboard port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project are documented here. This project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html). Release notes for
+versions prior to 1.0.7 are in the **What's new** sections of the [README](README.md).
+
+## [1.0.7]
+
+### Added
+- Support for **password-protected dashboards**: the Memory, Cron Jobs, Skills,
+  and Settings screens now authenticate against a basic-auth dashboard via the
+  `/auth/password-login` flow and reuse the returned session cookie. Open
+  (`--insecure`) dashboards continue to work via the existing token scrape.
+- **Configurable dashboard port** per connection (`dashboardPortOverride`),
+  defaulting to the previous behaviour (`9119` for HTTP, the external port for
+  HTTPS) when unset.
+- **Dashboard details in the Add Connection dialog** under a collapsible
+  "Custom dashboard details" section, plus a **Dashboard Login** entry on each
+  connection's overflow menu. Both validate the dashboard before saving.
+
+### Changed
+- `DashboardClient` accepts an optional `http.Client` for testability and
+  de-duplicates concurrent login / token requests.
+
+### Fixed
+- Updating a connection's API key no longer clears its saved dashboard settings.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,17 @@ Android client for [Hermes Agent](https://hermes-agent.nousresearch.com/) — ch
 
 ## Current release
 
-- Version: **1.0.6**
+- Version: **1.0.7**
 - Package: `com.hermesagent.hermes_android`
 - Recommended APK for most modern phones: `app-arm64-v8a-release.apk`
 - Other APKs: `app-armeabi-v7a-release.apk`, `app-x86_64-release.apk`
 - Download: [GitHub Releases](https://github.com/rusty4444/hermes-android/releases/latest)
+
+## What's new in v1.0.7
+
+- **Password-protected dashboards** — the Memory/Cron/Skills/Settings tabs now work against a dashboard secured with basic-auth, not just an open (`--insecure`) one. The app logs in via the dashboard's `/auth/password-login` flow and reuses the session cookie (the same mechanism the desktop client uses).
+- **Configurable dashboard port** — set a custom dashboard port per connection when it isn't the default `9119`.
+- **Dashboard details in the connection flow** — set the dashboard port/username/password while adding a connection (expand **Custom dashboard details**) or later via **⋮ → Dashboard Login**, with validation before saving.
 
 ## What's new in v1.0.6
 
@@ -23,7 +29,7 @@ Android client for [Hermes Agent](https://hermes-agent.nousresearch.com/) — ch
 - **Messaging-style UI** — dark/light/system themes, gold Hermes accent color (`#D4AF37`), markdown rendering, relative timestamps, and responsive phone/tablet layouts.
 - **Gold/black Hermes branding** — distinctive gold accent on black background, custom app icon with mipmap densities, agent messages use grey bubbles.
 - **Gateway API integration** — sessions and chat run through the Hermes Gateway API Server, normally on port `8642`, with HTTP and HTTPS endpoints supported.
-- **Dashboard integrations** — Memory, Cron Jobs, Skills, and Settings screens use the Hermes dashboard API, normally on port `9119`, on the same host.
+- **Dashboard integrations** — Memory, Cron Jobs, Skills, and Settings screens use the Hermes dashboard API (default port `9119`, configurable per connection) on the same host. Works with both open (`--insecure`) dashboards and **password-protected dashboards** via the built-in login.
 - **Model settings** — view and change the configured Hermes model where the dashboard exposes model settings.
 - **Cron management** — list, trigger, pause/resume, create, edit, and delete scheduled Hermes cron jobs.
 - **Skills browser** — view available Hermes skills with descriptions and trigger conditions.
@@ -87,11 +93,17 @@ Use your normal Hermes gateway/API-server startup command and confirm:
 
 ### 2. Optional: start the dashboard for drawer features
 
-Memory, Cron Jobs, Skills, and Settings use the Hermes dashboard API on port `9119`:
+Memory, Cron Jobs, Skills, and Settings use the Hermes dashboard API (default port `9119`).
+
+Open dashboard (no login):
 
 ```bash
 hermes dashboard --insecure --host 0.0.0.0 --tui --port 9119
 ```
+
+Password-protected dashboard (recommended on shared networks) — start it with a
+basic-auth provider instead of `--insecure`, then enter the username/password in
+the app's **Dashboard Login** dialog (see [Dashboard access](#4-optional-configure-dashboard-access)).
 
 > `--host 0.0.0.0` is required when connecting from another device. A localhost-only dashboard cannot be reached from Android.
 
@@ -117,6 +129,28 @@ hermes dashboard --insecure --host 0.0.0.0 --tui --port 9119
    - **API Key:** `API_SERVER_KEY` from the Hermes machine
 6. Tap the saved connection to browse sessions.
 7. Tap a session to start chatting, or create a new one.
+
+### 4. Optional: configure dashboard access
+
+The drawer screens (Memory, Cron Jobs, Skills, Settings) talk to the Hermes
+dashboard, which can run on a different port from the Gateway API Server and may
+be password-protected. Configure it per connection — either while adding the
+connection (expand **Custom dashboard details** in the Add Connection dialog) or
+afterwards:
+
+1. On the connections list, tap the **⋮** menu on a connection → **Dashboard Login**.
+2. Fill in:
+   - **Dashboard Port** — leave blank to use the default (`9119` for HTTP, or the
+     same external port for HTTPS deployments), or set an explicit port if your
+     dashboard is exposed elsewhere.
+   - **Username / Password** — only for a password-protected dashboard. Leave
+     both blank for an open (`--insecure`) dashboard.
+3. Tap **Save**. The app validates the settings against the dashboard before
+   storing them.
+
+When credentials are set, the app authenticates via the dashboard's
+`/auth/password-login` flow and reuses the returned session cookie — the same
+mechanism the Hermes desktop client uses.
 
 ## Connect remotely with Tailscale
 
@@ -344,8 +378,9 @@ Check that the Android connection's API key matches `API_SERVER_KEY` from the He
 
 ### Dashboard screens show empty or error
 
-- Verify the dashboard is running with `--host 0.0.0.0 --insecure`.
-- Check the dashboard port matches the connection (port `9119` for local/Tailscale, same HTTPS port for hosted).
+- Verify the dashboard is running with `--host 0.0.0.0` (an open dashboard also needs `--insecure`).
+- If the dashboard is password-protected, set the username/password under **⋮ → Dashboard Login** (or **Custom dashboard details** when adding the connection). A 401 here means the credentials are wrong.
+- Check the dashboard port matches the connection (default `9119` for local/Tailscale, same HTTPS port for hosted; override it in Dashboard Login if needed).
 - The dashboard must be on the same host as the Gateway API Server for the app's drawer to reach it.
 
 ### Voice dictation or spoken replies aren't working

--- a/lib/core/models/connection.dart
+++ b/lib/core/models/connection.dart
@@ -19,6 +19,19 @@ class SavedConnection {
   final String apiKey;
   final bool useHttps;
 
+  /// Explicit dashboard port. When null, [dashboardPort] falls back to the
+  /// default topology (see below). Set this when the dashboard is exposed on a
+  /// non-default port.
+  final int? dashboardPortOverride;
+
+  /// Optional dashboard credentials for a basic-auth (password-protected)
+  /// dashboard. When both are set, [DashboardClient] performs the
+  /// `/auth/password-login` flow and authenticates with the resulting session
+  /// cookie (same as hermes-desktop). When empty, it falls back to scraping the
+  /// SPA session token, which only works on an insecure (open) dashboard.
+  final String? dashboardUsername;
+  final String? dashboardPassword;
+
   SavedConnection({
     required this.id,
     required this.label,
@@ -26,6 +39,9 @@ class SavedConnection {
     required this.port,
     required this.apiKey,
     this.useHttps = false,
+    this.dashboardPortOverride,
+    this.dashboardUsername,
+    this.dashboardPassword,
   });
 
   String get baseUrl {
@@ -36,8 +52,10 @@ class SavedConnection {
   /// Dashboard/API-server topology differs between local LAN and HTTPS proxy
   /// setups. Local Gateway chat connections normally use 8642 while the
   /// dashboard lives on 9119. HTTPS reverse-proxy deployments usually expose
-  /// both API surfaces on the same external HTTPS port.
-  int get dashboardPort => useHttps ? port : 9119;
+  /// both API surfaces on the same external HTTPS port. An explicit
+  /// [dashboardPortOverride] always wins.
+  int get dashboardPort =>
+      dashboardPortOverride ?? (useHttps ? port : 9119);
 
   /// Parses [input] as a URI and extracts host, port, and HTTPS flag.
   ///
@@ -92,10 +110,18 @@ class SavedConnection {
       'port': port,
       'api_key': apiKey,
       'use_https': useHttps,
+      'dashboard_port': dashboardPortOverride,
+      'dashboard_username': dashboardUsername,
+      'dashboard_password': dashboardPassword,
     };
   }
 
   factory SavedConnection.fromMap(Map<String, dynamic> map) {
+    String? nonEmpty(Object? v) {
+      final s = (v as String?)?.trim();
+      return (s == null || s.isEmpty) ? null : s;
+    }
+
     return SavedConnection(
       id: map['id'] as String,
       label: map['label'] as String,
@@ -103,6 +129,44 @@ class SavedConnection {
       port: (map['port'] as int?) ?? 8642,
       apiKey: (map['api_key'] as String?) ?? '',
       useHttps: (map['use_https'] as bool?) ?? false,
+      dashboardPortOverride: map['dashboard_port'] as int?,
+      dashboardUsername: nonEmpty(map['dashboard_username']),
+      dashboardPassword: nonEmpty(map['dashboard_password']),
+    );
+  }
+
+  /// Returns a copy with the given fields replaced. Pass `clearDashboard*`
+  /// flags to explicitly null out optional fields (since null args can't
+  /// distinguish "leave unchanged" from "clear").
+  SavedConnection copyWith({
+    String? label,
+    String? host,
+    int? port,
+    String? apiKey,
+    bool? useHttps,
+    int? dashboardPortOverride,
+    String? dashboardUsername,
+    String? dashboardPassword,
+    bool clearDashboardPort = false,
+    bool clearDashboardUsername = false,
+    bool clearDashboardPassword = false,
+  }) {
+    return SavedConnection(
+      id: id,
+      label: label ?? this.label,
+      host: host ?? this.host,
+      port: port ?? this.port,
+      apiKey: apiKey ?? this.apiKey,
+      useHttps: useHttps ?? this.useHttps,
+      dashboardPortOverride: clearDashboardPort
+          ? null
+          : (dashboardPortOverride ?? this.dashboardPortOverride),
+      dashboardUsername: clearDashboardUsername
+          ? null
+          : (dashboardUsername ?? this.dashboardUsername),
+      dashboardPassword: clearDashboardPassword
+          ? null
+          : (dashboardPassword ?? this.dashboardPassword),
     );
   }
 }

--- a/lib/core/screens/cron_screen.dart
+++ b/lib/core/screens/cron_screen.dart
@@ -30,6 +30,8 @@ class _CronScreenState extends State<CronScreen> {
       host: widget.connection.host,
       port: widget.connection.dashboardPort,
       useHttps: widget.connection.useHttps,
+      username: widget.connection.dashboardUsername,
+      password: widget.connection.dashboardPassword,
     );
     _loadJobs();
   }

--- a/lib/core/screens/memory_screen.dart
+++ b/lib/core/screens/memory_screen.dart
@@ -31,6 +31,8 @@ class _MemoryScreenState extends State<MemoryScreen> {
       host: widget.connection.host,
       port: widget.connection.dashboardPort,
       useHttps: widget.connection.useHttps,
+      username: widget.connection.dashboardUsername,
+      password: widget.connection.dashboardPassword,
     );
     _loadMemory();
   }

--- a/lib/core/screens/settings_screen.dart
+++ b/lib/core/screens/settings_screen.dart
@@ -34,6 +34,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
       host: widget.connection.host,
       port: widget.connection.dashboardPort,
       useHttps: widget.connection.useHttps,
+      username: widget.connection.dashboardUsername,
+      password: widget.connection.dashboardPassword,
     );
     _loadData();
   }

--- a/lib/core/screens/skills_screen.dart
+++ b/lib/core/screens/skills_screen.dart
@@ -23,6 +23,8 @@ class _SkillsScreenState extends State<SkillsScreen> {
       host: widget.connection.host,
       port: widget.connection.dashboardPort,
       useHttps: widget.connection.useHttps,
+      username: widget.connection.dashboardUsername,
+      password: widget.connection.dashboardPassword,
     );
     _load();
   }

--- a/lib/core/services/connection_manager.dart
+++ b/lib/core/services/connection_manager.dart
@@ -28,7 +28,15 @@ class ConnectionManager {
     }).toList();
   }
 
-  void saveConnection(String label, String host, int port, String apiKey) {
+  void saveConnection(
+    String label,
+    String host,
+    int port,
+    String apiKey, {
+    int? dashboardPort,
+    String? dashboardUsername,
+    String? dashboardPassword,
+  }) {
     final normalized = SavedConnection.normalizeHostAndPort(host, port);
     final conn = SavedConnection(
       id: _uuid.v4(),
@@ -37,9 +45,36 @@ class ConnectionManager {
       port: normalized.port,
       apiKey: apiKey,
       useHttps: normalized.useHttps,
+      dashboardPortOverride: dashboardPort,
+      dashboardUsername: dashboardUsername,
+      dashboardPassword: dashboardPassword,
     );
     final current = getConnections();
     current.insert(0, conn);
+    _saveAll(current);
+  }
+
+  /// Updates the dashboard port + basic-auth credentials on an existing
+  /// connection. Empty strings clear the corresponding field.
+  void updateDashboardAuth(
+    String connId, {
+    int? dashboardPort,
+    required String username,
+    required String password,
+  }) {
+    final current = getConnections();
+    final idx = current.indexWhere((c) => c.id == connId);
+    if (idx < 0) return;
+    final u = username.trim();
+    final p = password.trim();
+    current[idx] = current[idx].copyWith(
+      dashboardPortOverride: dashboardPort,
+      clearDashboardPort: dashboardPort == null,
+      dashboardUsername: u.isEmpty ? null : u,
+      clearDashboardUsername: u.isEmpty,
+      dashboardPassword: p.isEmpty ? null : p,
+      clearDashboardPassword: p.isEmpty,
+    );
     _saveAll(current);
   }
 
@@ -47,14 +82,7 @@ class ConnectionManager {
     final current = getConnections();
     final idx = current.indexWhere((c) => c.id == connId);
     if (idx < 0) return;
-    current[idx] = SavedConnection(
-      id: current[idx].id,
-      label: current[idx].label,
-      host: current[idx].host,
-      port: current[idx].port,
-      apiKey: apiKey,
-      useHttps: current[idx].useHttps,
-    );
+    current[idx] = current[idx].copyWith(apiKey: apiKey);
     _saveAll(current);
   }
 
@@ -398,40 +426,137 @@ class GatewayChatClient {
   }
 }
 
-/// Client for the Hermes Dashboard REST API (port 9119).
+/// Client for the Hermes Dashboard REST API.
 ///
-/// Auto-discovers the ephemeral SPA session token by fetching the dashboard
-/// homepage. Used for Dashboard-only features: cron, memory, skills, settings.
+/// Two auth modes, picked by whether dashboard credentials are supplied:
+///
+///  * **Password (gated) dashboard** — when [username] and [password] are set,
+///    performs the `/auth/password-login` flow (provider `basic`) and
+///    authenticates subsequent `/api/` calls with the returned
+///    `hermes_session_at` session cookie. This is what hermes-desktop does and
+///    is required when the dashboard runs with basic-auth.
+///  * **Insecure (open) dashboard** — when no credentials are given, falls back
+///    to scraping the ephemeral SPA session token from the homepage. Only works
+///    on a dashboard started with `--insecure`.
+///
+/// Used for Dashboard-only features: cron, memory, skills, settings.
 class DashboardClient {
   final http.Client _http;
   final String _baseUrl;
+  final String? _username;
+  final String? _password;
   String? _token;
+  String? _cookie;
+  // In-flight auth requests, shared so concurrent /api calls trigger a single
+  // login / token fetch instead of a thundering herd (the dashboard
+  // rate-limits password logins).
+  Future<String>? _cookieInFlight;
+  Future<String>? _tokenInFlight;
 
   String get baseUrl => _baseUrl;
+
+  bool get _usesPasswordAuth =>
+      (_username?.isNotEmpty ?? false) && (_password?.isNotEmpty ?? false);
 
   DashboardClient({
     required String host,
     int port = 9119,
     bool useHttps = false,
+    String? username,
+    String? password,
+    http.Client? httpClient,
   }) : _baseUrl = '${useHttps ? 'https' : 'http'}://$host:$port',
-       _http = http.Client();
+       _username = username,
+       _password = password,
+       _http = httpClient ?? http.Client();
 
-  Future<String> _getToken() async {
-    if (_token != null) return _token!;
-    final res = await _http.get(Uri.parse('$_baseUrl/'));
-    if (res.statusCode != 200) throw Exception('Dashboard not reachable');
-    final match = RegExp(
-      r'window\.__HERMES_SESSION_TOKEN__="([^"]+)";',
-    ).firstMatch(res.body);
-    if (match == null) throw Exception('Session token not found');
-    _token = match.group(1)!;
-    return _token!;
+  /// Clears any cached auth state so the next request re-authenticates.
+  void _resetAuth() {
+    _token = null;
+    _cookie = null;
+    _cookieInFlight = null;
+    _tokenInFlight = null;
   }
 
-  Future<Map<String, String>> _authHeaders() async => {
-    'X-Hermes-Session-Token': await _getToken(),
-    'Content-Type': 'application/json',
-  };
+  /// Returns the session cookie, reusing a cached value or an in-flight login.
+  Future<String> _getCookie() {
+    final cached = _cookie;
+    if (cached != null) return Future.value(cached);
+    return _cookieInFlight ??= _login();
+  }
+
+  /// Logs in against the `basic` password provider and caches the session
+  /// cookie. Throws on failure (bad credentials → 401, etc.).
+  Future<String> _login() async {
+    try {
+      final res = await _http.post(
+        Uri.parse('$_baseUrl/auth/password-login'),
+        headers: const {'Content-Type': 'application/json'},
+        body: jsonEncode({
+          'provider': 'basic',
+          'username': _username,
+          'password': _password,
+        }),
+      );
+      if (res.statusCode == 401) {
+        throw Exception('Dashboard login failed: invalid username or password');
+      }
+      if (res.statusCode != 200) {
+        throw Exception('Dashboard login failed: HTTP ${res.statusCode}');
+      }
+      final setCookie = res.headers['set-cookie'] ?? '';
+      // The `http` package folds multiple Set-Cookie headers into one
+      // comma-joined string; cookie expiry dates also contain commas, so match
+      // the access-token cookie by name and take its value up to the first
+      // delimiter. Handles the bare name plus the __Host-/__Secure- prefixes
+      // Hermes uses on HTTPS binds.
+      final match = RegExp(
+        r'((?:__Host-|__Secure-)?hermes_session_at)=([^;,\s]+)',
+      ).firstMatch(setCookie);
+      if (match == null) {
+        throw Exception('Dashboard login succeeded but no session cookie found');
+      }
+      _cookie = '${match.group(1)}=${match.group(2)}';
+      return _cookie!;
+    } finally {
+      _cookieInFlight = null;
+    }
+  }
+
+  /// Returns the SPA session token, reusing a cached value or an in-flight fetch.
+  Future<String> _getToken() {
+    final cached = _token;
+    if (cached != null) return Future.value(cached);
+    return _tokenInFlight ??= _fetchToken();
+  }
+
+  Future<String> _fetchToken() async {
+    try {
+      final res = await _http.get(Uri.parse('$_baseUrl/'));
+      if (res.statusCode != 200) throw Exception('Dashboard not reachable');
+      final match = RegExp(
+        r'window\.__HERMES_SESSION_TOKEN__="([^"]+)";',
+      ).firstMatch(res.body);
+      if (match == null) throw Exception('Session token not found');
+      _token = match.group(1)!;
+      return _token!;
+    } finally {
+      _tokenInFlight = null;
+    }
+  }
+
+  Future<Map<String, String>> _authHeaders() async {
+    if (_usesPasswordAuth) {
+      return {
+        'Cookie': await _getCookie(),
+        'Content-Type': 'application/json',
+      };
+    }
+    return {
+      'X-Hermes-Session-Token': await _getToken(),
+      'Content-Type': 'application/json',
+    };
+  }
 
   Map<String, dynamic> _decodeMapResponse(http.Response res) {
     final trimmed = res.body.trim();
@@ -451,7 +576,7 @@ class DashboardClient {
       headers: headers,
     );
     if (res.statusCode == 401 && !retried) {
-      _token = null;
+      _resetAuth();
       return apiGet(endpoint, retried: true);
     }
     if (res.statusCode != 200) throw Exception('HTTP ${res.statusCode}');
@@ -468,7 +593,7 @@ class DashboardClient {
       headers: headers,
     );
     if (res.statusCode == 401 && !retried) {
-      _token = null;
+      _resetAuth();
       return apiGetList(endpoint, retried: true);
     }
     if (res.statusCode != 200) throw Exception('HTTP ${res.statusCode}');
@@ -492,7 +617,7 @@ class DashboardClient {
       body: body != null ? jsonEncode(body) : null,
     );
     if (res.statusCode == 401 && !retried) {
-      _token = null;
+      _resetAuth();
       return apiPost(endpoint, body: body, retried: true);
     }
     if (res.statusCode < 200 || res.statusCode >= 300) {
@@ -508,7 +633,7 @@ class DashboardClient {
       headers: headers,
     );
     if (res.statusCode == 401 && !retried) {
-      _token = null;
+      _resetAuth();
       return apiDelete(endpoint, retried: true);
     }
     if (res.statusCode < 200 || res.statusCode >= 300) {
@@ -528,7 +653,7 @@ class DashboardClient {
       body: body != null ? jsonEncode(body) : null,
     );
     if (res.statusCode == 401 && !retried) {
-      _token = null;
+      _resetAuth();
       return apiPut(endpoint, body: body, retried: true);
     }
     if (res.statusCode < 200 || res.statusCode >= 300) {
@@ -586,7 +711,7 @@ class DashboardClient {
       body: jsonEncode(buildCronUpdateBody(updates)),
     );
     if (res.statusCode == 401 && !retried) {
-      _token = null;
+      _resetAuth();
       return updateJob(jobId, updates, retried: true);
     }
     if (res.statusCode < 200 || res.statusCode >= 300) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -203,10 +203,27 @@ class _HomeScreenState extends State<HomeScreen> {
     showDialog(
       context: context,
       builder: (_) => _AddDialog(
-        onSave: (label, host, port, apiKey) {
-          widget.connManager.saveConnection(label, host, port, apiKey);
-          _refresh();
-        },
+        onSave:
+            (
+              label,
+              host,
+              port,
+              apiKey, {
+              dashboardPort,
+              dashboardUsername,
+              dashboardPassword,
+            }) {
+              widget.connManager.saveConnection(
+                label,
+                host,
+                port,
+                apiKey,
+                dashboardPort: dashboardPort,
+                dashboardUsername: dashboardUsername,
+                dashboardPassword: dashboardPassword,
+              );
+              _refresh();
+            },
       ),
     );
   }
@@ -327,6 +344,164 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
+  void _showDashboardAuthDialog(SavedConnection conn) {
+    final portCtrl = TextEditingController(
+      text: conn.dashboardPortOverride?.toString() ?? '',
+    );
+    final userCtrl = TextEditingController(text: conn.dashboardUsername ?? '');
+    final passCtrl = TextEditingController(text: conn.dashboardPassword ?? '');
+    bool validating = false;
+    String? error;
+
+    showDialog(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setDialogState) => AlertDialog(
+          title: const Text('Dashboard Login'),
+          content: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: Text(
+                    'Used for the Settings, Memory, Skills and Cron tabs. '
+                    'Set the dashboard port and, if the dashboard is '
+                    'password-protected, the username and password. Leave '
+                    'username/password blank for an open (insecure) dashboard.',
+                    style: TextStyle(color: Colors.grey[600], fontSize: 12),
+                  ),
+                ),
+                if (error != null)
+                  Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.all(10),
+                    margin: const EdgeInsets.only(bottom: 12),
+                    decoration: BoxDecoration(
+                      color: Colors.red.withValues(alpha: 0.1),
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(color: Colors.red.withValues(alpha: 0.3)),
+                    ),
+                    child: Row(
+                      children: [
+                        const Icon(Icons.error_outline, color: Colors.red, size: 18),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            error!,
+                            style: const TextStyle(color: Colors.red, fontSize: 13),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                TextField(
+                  controller: portCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'Dashboard Port',
+                    hintText: 'Leave blank for default (9119)',
+                  ),
+                  keyboardType: TextInputType.number,
+                  enabled: !validating,
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: userCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'Username (optional)',
+                  ),
+                  autocorrect: false,
+                  enabled: !validating,
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: passCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'Password (optional)',
+                  ),
+                  obscureText: true,
+                  enabled: !validating,
+                ),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: validating ? null : () => Navigator.pop(ctx),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: validating
+                  ? null
+                  : () async {
+                      final portText = portCtrl.text.trim();
+                      final port = portText.isEmpty
+                          ? null
+                          : int.tryParse(portText);
+                      if (portText.isNotEmpty && (port == null || port <= 0)) {
+                        setDialogState(() => error = 'Invalid port number.');
+                        return;
+                      }
+                      final user = userCtrl.text.trim();
+                      final pass = passCtrl.text.trim();
+
+                      setDialogState(() {
+                        validating = true;
+                        error = null;
+                      });
+
+                      final client = DashboardClient(
+                        host: conn.host,
+                        port: port ?? conn.dashboardPort,
+                        useHttps: conn.useHttps,
+                        username: user.isEmpty ? null : user,
+                        password: pass.isEmpty ? null : pass,
+                      );
+                      try {
+                        await client.getModelInfo();
+                        client.close();
+                        if (!ctx.mounted) return;
+                        widget.connManager.updateDashboardAuth(
+                          conn.id,
+                          dashboardPort: port,
+                          username: user,
+                          password: pass,
+                        );
+                        _refresh();
+                        Navigator.pop(ctx);
+                      } catch (e) {
+                        client.close();
+                        if (!ctx.mounted) return;
+                        setDialogState(() {
+                          error =
+                              'Could not reach/authenticate the dashboard at '
+                              '${conn.host}:${port ?? conn.dashboardPort}. '
+                              'Check the port and credentials.';
+                          validating = false;
+                        });
+                      }
+                    },
+              child: validating
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: Colors.white,
+                      ),
+                    )
+                  : const Text('Save'),
+            ),
+          ],
+        ),
+      ),
+    ).whenComplete(() {
+      portCtrl.dispose();
+      userCtrl.dispose();
+      passCtrl.dispose();
+    });
+  }
+
   Widget _buildConnectionCard(SavedConnection conn) {
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
@@ -344,10 +519,16 @@ class _HomeScreenState extends State<HomeScreen> {
               _refresh();
             } else if (v == 'apikey') {
               _showApiKeyDialog(conn);
+            } else if (v == 'dashboard') {
+              _showDashboardAuthDialog(conn);
             }
           },
           itemBuilder: (_) => [
             const PopupMenuItem(value: 'apikey', child: Text('Update API Key')),
+            const PopupMenuItem(
+              value: 'dashboard',
+              child: Text('Dashboard Login'),
+            ),
             const PopupMenuItem(
               value: 'delete',
               child: Text('Delete', style: TextStyle(color: Colors.red)),
@@ -427,7 +608,15 @@ class _HomeScreenState extends State<HomeScreen> {
 }
 
 class _AddDialog extends StatefulWidget {
-  final void Function(String label, String host, int port, String apiKey)
+  final void Function(
+    String label,
+    String host,
+    int port,
+    String apiKey, {
+    int? dashboardPort,
+    String? dashboardUsername,
+    String? dashboardPassword,
+  })
   onSave;
   const _AddDialog({required this.onSave});
 
@@ -440,6 +629,10 @@ class _AddDialogState extends State<_AddDialog> {
   final _host = TextEditingController();
   final _port = TextEditingController(text: '8642');
   final _apiKey = TextEditingController();
+  final _dashPort = TextEditingController();
+  final _dashUser = TextEditingController();
+  final _dashPass = TextEditingController();
+  bool _showDashboard = false;
   bool _validating = false;
   String? _error;
 
@@ -472,17 +665,68 @@ class _AddDialogState extends State<_AddDialog> {
 
       if (!mounted) return;
 
-      if (ok) {
-        widget.onSave(label, host, port, apiKey);
-        Navigator.pop(context);
-      } else {
+      if (!ok) {
         setState(() {
           _error = apiKey.isEmpty
               ? 'Server requires an API key. Enter your API_SERVER_KEY.'
               : 'Invalid API key. Server returned 401.';
           _validating = false;
         });
+        return;
       }
+
+      final dashPortText = _dashPort.text.trim();
+      final dashUser = _dashUser.text.trim();
+      final dashPass = _dashPass.text.trim();
+      final dashPort = dashPortText.isEmpty ? null : int.tryParse(dashPortText);
+
+      // If the user supplied any dashboard details, validate them before saving
+      // (parity with the Dashboard Login dialog). The gateway is already known
+      // good at this point.
+      if (dashPortText.isNotEmpty || dashUser.isNotEmpty || dashPass.isNotEmpty) {
+        final dashClient = DashboardClient(
+          host: normalized.host,
+          port: SavedConnection(
+            id: '',
+            label: '',
+            host: normalized.host,
+            port: normalized.port,
+            apiKey: '',
+            useHttps: normalized.useHttps,
+            dashboardPortOverride: dashPort,
+          ).dashboardPort,
+          useHttps: normalized.useHttps,
+          username: dashUser.isEmpty ? null : dashUser,
+          password: dashPass.isEmpty ? null : dashPass,
+        );
+        try {
+          await dashClient.getModelInfo();
+        } catch (_) {
+          dashClient.close();
+          if (!mounted) return;
+          setState(() {
+            _error =
+                'Gateway connected, but the dashboard could not be reached or '
+                'authenticated. Check the dashboard details, or clear them to skip.';
+            _validating = false;
+            _showDashboard = true;
+          });
+          return;
+        }
+        dashClient.close();
+        if (!mounted) return;
+      }
+
+      widget.onSave(
+        label,
+        host,
+        port,
+        apiKey,
+        dashboardPort: dashPort,
+        dashboardUsername: dashUser.isEmpty ? null : dashUser,
+        dashboardPassword: dashPass.isEmpty ? null : dashPass,
+      );
+      Navigator.pop(context);
     } catch (e) {
       if (!mounted) return;
       setState(() {
@@ -561,6 +805,63 @@ class _AddDialogState extends State<_AddDialog> {
               ),
               obscureText: true,
             ),
+            const SizedBox(height: 4),
+            InkWell(
+              onTap: _validating
+                  ? null
+                  : () => setState(() => _showDashboard = !_showDashboard),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: Row(
+                  children: [
+                    Icon(
+                      _showDashboard ? Icons.expand_less : Icons.expand_more,
+                      size: 20,
+                      color: Colors.grey[500],
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      'Custom dashboard details',
+                      style: TextStyle(color: Colors.grey[500], fontSize: 13),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            if (_showDashboard) ...[
+              Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: Text(
+                  'Optional. For the Memory/Cron/Skills/Settings tabs. Leave '
+                  'blank to use the default dashboard port (9119) with no login.',
+                  style: TextStyle(color: Colors.grey[600], fontSize: 12),
+                ),
+              ),
+              TextField(
+                controller: _dashPort,
+                decoration: const InputDecoration(
+                  labelText: 'Dashboard Port',
+                  hintText: 'Leave blank for default (9119)',
+                ),
+                keyboardType: TextInputType.number,
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _dashUser,
+                decoration: const InputDecoration(
+                  labelText: 'Dashboard Username (optional)',
+                ),
+                autocorrect: false,
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _dashPass,
+                decoration: const InputDecoration(
+                  labelText: 'Dashboard Password (optional)',
+                ),
+                obscureText: true,
+              ),
+            ],
           ],
         ),
       ),
@@ -592,6 +893,9 @@ class _AddDialogState extends State<_AddDialog> {
     _host.dispose();
     _port.dispose();
     _apiKey.dispose();
+    _dashPort.dispose();
+    _dashUser.dispose();
+    _dashPass.dispose();
     super.dispose();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hermes_android
 description: "Hermes Agent — chat with your Hermes Gateway API Server over LAN. SSE streaming, Bearer auth, session management."
 publish_to: 'none'
-version: 1.0.6+106
+version: 1.0.7+107
 
 environment:
   sdk: ^3.12.0

--- a/test/connection_manager_test.dart
+++ b/test/connection_manager_test.dart
@@ -1,7 +1,20 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:hermes_android/core/services/connection_manager.dart';
+
+/// Case-insensitive request header lookup — package:http normalises header
+/// names when sending, so tests should not assume a particular casing.
+String? _header(http.BaseRequest request, String name) {
+  final lower = name.toLowerCase();
+  for (final entry in request.headers.entries) {
+    if (entry.key.toLowerCase() == lower) return entry.value;
+  }
+  return null;
+}
 
 void main() {
   group('SavedConnection', () {
@@ -96,6 +109,107 @@ void main() {
         ).baseUrl,
         'https://hermes.example.com:443',
       );
+    });
+
+    test('explicit dashboard port override wins over topology default', () {
+      final local = SavedConnection(
+        id: '1',
+        label: 'Home',
+        host: '192.168.1.50',
+        port: 8642,
+        apiKey: 'key',
+        dashboardPortOverride: 30433,
+      );
+      expect(local.dashboardPort, 30433);
+
+      final https = SavedConnection(
+        id: '2',
+        label: 'Remote',
+        host: 'hermes.example.com',
+        port: 443,
+        apiKey: 'key',
+        useHttps: true,
+        dashboardPortOverride: 8443,
+      );
+      expect(https.dashboardPort, 8443);
+    });
+
+    test('round-trips dashboard port and credentials through toMap/fromMap', () {
+      final conn = SavedConnection(
+        id: '1',
+        label: 'Home',
+        host: '192.168.1.50',
+        port: 8642,
+        apiKey: 'key',
+        dashboardPortOverride: 30433,
+        dashboardUsername: 'misha',
+        dashboardPassword: 'secret',
+      );
+
+      final restored = SavedConnection.fromMap(conn.toMap());
+      expect(restored.dashboardPortOverride, 30433);
+      expect(restored.dashboardUsername, 'misha');
+      expect(restored.dashboardPassword, 'secret');
+      expect(restored.dashboardPort, 30433);
+    });
+
+    test('fromMap is backward compatible with maps lacking dashboard keys', () {
+      final restored = SavedConnection.fromMap({
+        'id': '2',
+        'label': 'Old',
+        'host': '192.168.1.50',
+        'port': 8642,
+        'api_key': 'key',
+      });
+      expect(restored.dashboardPortOverride, isNull);
+      expect(restored.dashboardUsername, isNull);
+      expect(restored.dashboardPassword, isNull);
+      expect(restored.dashboardPort, 9119);
+    });
+
+    test('fromMap normalises blank credentials to null', () {
+      final restored = SavedConnection.fromMap({
+        'id': '3',
+        'label': 'Blank',
+        'host': '192.168.1.50',
+        'port': 8642,
+        'api_key': 'key',
+        'dashboard_username': '   ',
+        'dashboard_password': '',
+      });
+      expect(restored.dashboardUsername, isNull);
+      expect(restored.dashboardPassword, isNull);
+    });
+
+    test('copyWith preserves unset fields and clears via flags', () {
+      final conn = SavedConnection(
+        id: '1',
+        label: 'Home',
+        host: '192.168.1.50',
+        port: 8642,
+        apiKey: 'key',
+        dashboardPortOverride: 30433,
+        dashboardUsername: 'misha',
+        dashboardPassword: 'secret',
+      );
+
+      final keyOnly = conn.copyWith(apiKey: 'new-key');
+      expect(keyOnly.apiKey, 'new-key');
+      expect(keyOnly.dashboardPortOverride, 30433);
+      expect(keyOnly.dashboardUsername, 'misha');
+      expect(keyOnly.dashboardPassword, 'secret');
+
+      final cleared = conn.copyWith(
+        clearDashboardPort: true,
+        clearDashboardUsername: true,
+        clearDashboardPassword: true,
+      );
+      expect(cleared.dashboardPortOverride, isNull);
+      expect(cleared.dashboardUsername, isNull);
+      expect(cleared.dashboardPassword, isNull);
+      // Identity and unrelated fields are retained.
+      expect(cleared.id, '1');
+      expect(cleared.apiKey, 'key');
     });
   });
 
@@ -208,6 +322,199 @@ void main() {
       expect(DashboardClient.buildCronUpdateBody(updates), {
         'updates': updates,
       });
+    });
+
+    test('logs in and authenticates /api calls with the session cookie', () async {
+      var loginCalls = 0;
+      final client = DashboardClient(
+        host: 'hermes.local',
+        port: 30433,
+        username: 'misha',
+        password: 'secret',
+        httpClient: MockClient((request) async {
+          if (request.url.path == '/auth/password-login') {
+            loginCalls++;
+            expect(request.method, 'POST');
+            expect(jsonDecode(request.body), {
+              'provider': 'basic',
+              'username': 'misha',
+              'password': 'secret',
+            });
+            return http.Response(
+              '{"ok":true}',
+              200,
+              headers: {
+                'set-cookie':
+                    'hermes_session_at=TOK123; Path=/; HttpOnly; SameSite=Lax',
+              },
+            );
+          }
+          if (request.url.path == '/api/model/info') {
+            // Cookie auth, not the insecure token header.
+            expect(_header(request, 'cookie'), 'hermes_session_at=TOK123');
+            expect(_header(request, 'x-hermes-session-token'), isNull);
+            return http.Response('{"model":"hermes-agent"}', 200);
+          }
+          return http.Response('not found', 404);
+        }),
+      );
+
+      final info = await client.getModelInfo();
+      expect(info['model'], 'hermes-agent');
+
+      // A second call reuses the cached cookie (no re-login).
+      await client.getModelInfo();
+      expect(loginCalls, 1);
+      client.close();
+    });
+
+    test('falls back to homepage token scrape when no credentials', () async {
+      final client = DashboardClient(
+        host: 'hermes.local',
+        port: 9119,
+        httpClient: MockClient((request) async {
+          if (request.url.path == '/') {
+            return http.Response(
+              '<script>window.__HERMES_SESSION_TOKEN__="SPA_TOK";</script>',
+              200,
+            );
+          }
+          if (request.url.path == '/api/model/info') {
+            expect(_header(request, 'x-hermes-session-token'), 'SPA_TOK');
+            expect(_header(request, 'cookie'), isNull);
+            return http.Response('{"model":"hermes-agent"}', 200);
+          }
+          return http.Response('not found', 404);
+        }),
+      );
+
+      final info = await client.getModelInfo();
+      expect(info['model'], 'hermes-agent');
+      client.close();
+    });
+
+    test('re-authenticates once on a 401 from an /api call', () async {
+      var apiCalls = 0;
+      var loginCalls = 0;
+      final client = DashboardClient(
+        host: 'hermes.local',
+        port: 30433,
+        username: 'misha',
+        password: 'secret',
+        httpClient: MockClient((request) async {
+          if (request.url.path == '/auth/password-login') {
+            loginCalls++;
+            final cookie = 'hermes_session_at=TOK$loginCalls';
+            return http.Response('{"ok":true}', 200,
+                headers: {'set-cookie': '$cookie; Path=/'});
+          }
+          if (request.url.path == '/api/model/info') {
+            apiCalls++;
+            // First attempt: stale cookie → 401. Retry: succeeds.
+            if (apiCalls == 1) return http.Response('unauthorized', 401);
+            expect(_header(request, 'cookie'), 'hermes_session_at=TOK2');
+            return http.Response('{"model":"hermes-agent"}', 200);
+          }
+          return http.Response('not found', 404);
+        }),
+      );
+
+      final info = await client.getModelInfo();
+      expect(info['model'], 'hermes-agent');
+      expect(apiCalls, 2);
+      expect(loginCalls, 2);
+      client.close();
+    });
+
+    test('surfaces invalid dashboard credentials', () async {
+      final client = DashboardClient(
+        host: 'hermes.local',
+        port: 30433,
+        username: 'misha',
+        password: 'wrong',
+        httpClient: MockClient((request) async {
+          if (request.url.path == '/auth/password-login') {
+            return http.Response('{"detail":"Invalid credentials"}', 401);
+          }
+          return http.Response('not found', 404);
+        }),
+      );
+
+      expect(client.getModelInfo(), throwsA(isA<Exception>()));
+      client.close();
+    });
+  });
+
+  group('ConnectionManager', () {
+    setUp(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('saveConnection persists dashboard port and credentials', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final mgr = ConnectionManager(prefs);
+      mgr.saveConnection(
+        'Home',
+        '192.168.1.50',
+        8642,
+        'key',
+        dashboardPort: 30433,
+        dashboardUsername: 'misha',
+        dashboardPassword: 'secret',
+      );
+
+      final conn = mgr.getConnections().single;
+      expect(conn.dashboardPortOverride, 30433);
+      expect(conn.dashboardUsername, 'misha');
+      expect(conn.dashboardPassword, 'secret');
+    });
+
+    test('updateDashboardAuth sets then clears fields', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final mgr = ConnectionManager(prefs);
+      mgr.saveConnection('Home', '192.168.1.50', 8642, 'key');
+      final id = mgr.getConnections().single.id;
+
+      mgr.updateDashboardAuth(
+        id,
+        dashboardPort: 30433,
+        username: 'misha',
+        password: 'secret',
+      );
+      var conn = mgr.getConnections().single;
+      expect(conn.dashboardPortOverride, 30433);
+      expect(conn.dashboardUsername, 'misha');
+      expect(conn.dashboardPassword, 'secret');
+
+      // Blank values clear the corresponding fields.
+      mgr.updateDashboardAuth(id, username: '', password: '');
+      conn = mgr.getConnections().single;
+      expect(conn.dashboardPortOverride, isNull);
+      expect(conn.dashboardUsername, isNull);
+      expect(conn.dashboardPassword, isNull);
+    });
+
+    test('updateApiKey preserves dashboard credentials', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final mgr = ConnectionManager(prefs);
+      mgr.saveConnection(
+        'Home',
+        '192.168.1.50',
+        8642,
+        'key',
+        dashboardPort: 30433,
+        dashboardUsername: 'misha',
+        dashboardPassword: 'secret',
+      );
+      final id = mgr.getConnections().single.id;
+
+      mgr.updateApiKey(id, 'new-key');
+      final conn = mgr.getConnections().single;
+      expect(conn.apiKey, 'new-key');
+      expect(conn.dashboardPortOverride, 30433);
+      expect(conn.dashboardUsername, 'misha');
+      expect(conn.dashboardPassword, 'secret');
     });
   });
 }


### PR DESCRIPTION
## Summary

The dashboard-backed screens (Memory, Cron Jobs, Skills, Settings) previously only worked against an **open** (`--insecure`) dashboard on the default port `9119`, because `DashboardClient` authenticated by scraping the SPA session token from the dashboard homepage — which is only injected in insecure mode.

This PR adds support for **password-protected dashboards** and **non-default dashboard ports**, while keeping the existing open-dashboard behaviour unchanged.

## What changed

- **`DashboardClient` cookie auth.** When dashboard credentials are configured, the client logs in via `POST /auth/password-login` (provider `basic`) and authenticates subsequent `/api/` calls with the returned `hermes_session_at` session cookie — the same mechanism the Hermes desktop client uses. With no credentials it falls back to the existing homepage token scrape, so open dashboards keep working.
- **Configurable dashboard port.** `SavedConnection` gains optional `dashboardPortOverride`, `dashboardUsername`, and `dashboardPassword` fields (persisted; `fromMap` is backward-compatible with existing saved connections). The `dashboardPort` getter honours the override and otherwise keeps the previous default (`9119` for HTTP, the external port for HTTPS).
- **UI.** A collapsible **"Custom dashboard details"** section in the Add Connection dialog (collapsed by default) and a **"Dashboard Login"** entry on each connection's overflow menu. Both validate the dashboard before saving.
- **Robustness.** `DashboardClient` now accepts an injectable `http.Client` (for tests) and de-duplicates concurrent login/token requests so parallel drawer calls trigger a single auth round-trip (the dashboard rate-limits password logins). Updating a connection's API key no longer clears its dashboard settings.

## How dashboard auth works now

```
no credentials set ->  GET /  -> scrape window.__HERMES_SESSION_TOKEN__  (open / --insecure dashboard)
credentials set    ->  POST /auth/password-login {provider:"basic",username,password}
                       -> Set-Cookie: hermes_session_at=...  -> sent on every /api/ call
```

## Backward compatibility

- Existing saved connections load unchanged (new fields default to null → previous behaviour).
- No changes to the Gateway API (chat/sessions) path.

## Testing

Added unit tests (`test/connection_manager_test.dart`):

- `SavedConnection`: port override precedence, `toMap`/`fromMap` round-trip, backward-compatible parsing, blank-credential normalisation, `copyWith`.
- `DashboardClient` (via injected `MockClient`): password→cookie login, token-scrape fallback, 401 re-authentication, and bad-credential error.
- `ConnectionManager`: persistence of the new fields, `updateDashboardAuth` set/clear, and API-key updates preserving dashboard settings.

## CODE_QUALITY_CHECKLIST

**Analysis**
- [x] `flutter analyze` — zero errors/warnings (CI runs `--fatal-infos`)
- [x] `flutter pub outdated` — N/A, no dependency changes
- [x] `flutter test` — passes (new tests added)
- [x] `flutter build apk --release --split-per-abi` — clean build in CI

**Architecture**
- [x] State management consistent (`setState` dialogs, matching existing code)
- [x] No orphaned imports / dead code
- [x] Network calls have visible error-handling paths
- [x] `StatefulWidget` resources disposed (new `TextEditingController`s disposed; the Dashboard Login dialog disposes its controllers on close)
- [x] Streaming/WebSocket lifecycles — N/A, unchanged

**UX**
- [x] Error states are visible (login/validation failures surfaced in the dialogs)
- [x] Loading indicators shown during validation
- [x] Responsive — noted: changes are dialog-based; existing phone/tablet layouts unchanged
- [x] Dark mode — unchanged
- [x] Forms validate and prevent bad submissions (gateway + optional dashboard validation before save)

**Security**
- [x] No secrets committed
- [x] User-provided hosts/URLs normalised before use
- [ ] Sensitive values masked — **noted exception:** the dashboard password is stored in `SharedPreferences` in plaintext, mirroring the existing `apiKey` handling. Migrating both to `flutter_secure_storage` is suggested as a separate follow-up.

**Release**
- [x] Version bumped in `pubspec.yaml` (`1.0.7+107`)
- [x] `CHANGELOG.md` added/updated
- [x] CI builds a clean APK
- [x] PR links to this checklist (above)

**Manual smoke testing**
- [x] Connect to a Gateway API Server
- [x] Browse sessions
- [x] Send a message and receive a streamed response
- [x] Open Memory/Cron/Skills/Settings against a **basic-auth** dashboard (configured via Dashboard Login)
- [x] Phone layout verified — noted: tablet layout not specifically re-tested for the new dialogs

## Known limitations / follow-ups

- Dashboard password (and the existing API key) are stored unencrypted in `SharedPreferences` — a `flutter_secure_storage` migration would be a good separate PR.
- The dashboard is assumed to be on the same host as the gateway; only the port is configurable, not a separate dashboard host.
