### PR TITLE
feat: proxy path prefix and proxied dashboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,17 @@ Android client for [Hermes Agent](https://hermes-agent.nousresearch.com/) — ch
 
 ## Current release
 
-- Version: **1.0.7**
+- Version: **1.0.8**
 - Package: `com.hermesagent.hermes_android`
 - Recommended APK for most modern phones: `app-arm64-v8a-release.apk`
 - Other APKs: `app-armeabi-v7a-release.apk`, `app-x86_64-release.apk`
 - Download: [GitHub Releases](https://github.com/rusty4444/hermes-android/releases/latest)
+
+## What's new in v1.0.8
+
+- **Reverse-proxy path prefixes** — configure separate path prefixes for the Gateway API and dashboard, e.g. `/profile/peter` before `/api` and `/v1`, and `/dashboard` before dashboard `/api` routes.
+- **Proxied dashboard mode** — enable **Dashboard behind proxy** when nginx/Caddy/your host injects dashboard authentication. In this mode the app sends clean dashboard requests without trying to scrape a dashboard session token or perform password login.
+- **Prefix-aware validation and chat** — API-key validation, session browsing, existing chat history, streaming chat completions, and dashboard drawer screens all use the configured prefixes.
 
 ## What's new in v1.0.7
 
@@ -28,8 +34,8 @@ Android client for [Hermes Agent](https://hermes-agent.nousresearch.com/) — ch
 - **Streaming responses** — chat uses the Hermes Gateway OpenAI-compatible streaming endpoint: `POST /v1/chat/completions`. Tokens appear in real-time with smooth auto-scroll.
 - **Messaging-style UI** — dark/light/system themes, gold Hermes accent color (`#D4AF37`), markdown rendering, relative timestamps, and responsive phone/tablet layouts.
 - **Gold/black Hermes branding** — distinctive gold accent on black background, custom app icon with mipmap densities, agent messages use grey bubbles.
-- **Gateway API integration** — sessions and chat run through the Hermes Gateway API Server, normally on port `8642`, with HTTP and HTTPS endpoints supported.
-- **Dashboard integrations** — Memory, Cron Jobs, Skills, and Settings screens use the Hermes dashboard API (default port `9119`, configurable per connection) on the same host. Works with both open (`--insecure`) dashboards and **password-protected dashboards** via the built-in login.
+- **Gateway API integration** — sessions and chat run through the Hermes Gateway API Server, normally on port `8642`, with HTTP and HTTPS endpoints supported. Reverse-proxy deployments can set a gateway path prefix that is applied before `/api` and `/v1` routes.
+- **Dashboard integrations** — Memory, Cron Jobs, Skills, and Settings screens use the Hermes dashboard API (default port `9119`, configurable per connection) on the same host. Works with open (`--insecure`) dashboards, **password-protected dashboards** via the built-in login, and proxied dashboards where auth is injected upstream.
 - **Model settings** — view and change the configured Hermes model where the dashboard exposes model settings.
 - **Cron management** — list, trigger, pause/resume, create, edit, and delete scheduled Hermes cron jobs.
 - **Skills browser** — view available Hermes skills with descriptions and trigger conditions.
@@ -127,19 +133,27 @@ the app's **Dashboard Login** dialog (see [Dashboard access](#4-optional-configu
    - **Host:** the host IP, e.g. `192.168.1.50`
    - **Port:** `8642`
    - **API Key:** `API_SERVER_KEY` from the Hermes machine
-6. Tap the saved connection to browse sessions.
-7. Tap a session to start chatting, or create a new one.
+6. If your deployment is behind a reverse proxy path, expand **Custom proxy and dashboard details** and set the gateway/dashboard prefixes there. Do not put URL paths in the Host field; the Host field is just the scheme, hostname, and optional port.
+7. Tap the saved connection to browse sessions.
+8. Tap a session to start chatting, or create a new one.
 
 ### 4. Optional: configure dashboard access
 
 The drawer screens (Memory, Cron Jobs, Skills, Settings) talk to the Hermes
 dashboard, which can run on a different port from the Gateway API Server and may
 be password-protected. Configure it per connection — either while adding the
-connection (expand **Custom dashboard details** in the Add Connection dialog) or
+connection (expand **Custom proxy and dashboard details** in the Add Connection dialog) or
 afterwards:
 
-1. On the connections list, tap the **⋮** menu on a connection → **Dashboard Login**.
+1. On the connections list, tap the **⋮** menu on a connection → **Dashboard / Proxy Settings**.
 2. Fill in:
+   - **Gateway path prefix** — optional reverse-proxy path before gateway `/api`
+     and `/v1` routes, e.g. `/profile/peter`.
+   - **Dashboard path prefix** — optional reverse-proxy path before dashboard
+     `/api` routes, e.g. `/dashboard`.
+   - **Dashboard behind proxy** — enable this when the proxy injects dashboard
+     authentication and the app should not fetch a dashboard SPA token or log in
+     with username/password.
    - **Dashboard Port** — leave blank to use the default (`9119` for HTTP, or the
      same external port for HTTPS deployments), or set an explicit port if your
      dashboard is exposed elsewhere.
@@ -211,6 +225,23 @@ If no port is included, the app uses port `443`. If your HTTPS service uses a cu
 
 For HTTPS connections, dashboard drawer screens use the same external HTTPS port. For local HTTP/LAN connections, chat uses port `8642` and dashboard screens use port `9119`.
 
+### Reverse-proxy paths
+
+If your proxy exposes Hermes under URL paths, keep the **Host** field to the origin only and put paths in **Custom proxy and dashboard details**:
+
+```text
+Host: https://your-hermes-host.example.com
+Port: 443
+Gateway path prefix: /profile/peter
+Dashboard path prefix: /dashboard
+Dashboard behind proxy: on, if the proxy injects dashboard auth
+```
+
+With that setup, the app calls gateway routes such as
+`https://your-hermes-host.example.com/profile/peter/v1/chat/completions` and
+dashboard routes such as
+`https://your-hermes-host.example.com/dashboard/api/model/info`.
+
 ### Security notes
 
 - Prefer Tailscale/VPN for remote use.
@@ -222,11 +253,11 @@ For HTTPS connections, dashboard drawer screens use the same external HTTPS port
 
 ```text
 Android app (Flutter)
-├─ Gateway API Server, port 8642
+├─ Gateway API Server, port 8642 or HTTPS proxy prefix
 │  ├─ GET /api/sessions
 │  ├─ GET /api/sessions/{id}/messages
 │  └─ POST /v1/chat/completions  (SSE streaming)
-└─ Hermes dashboard, port 9119
+└─ Hermes dashboard, port 9119 or HTTPS proxy prefix
    ├─ /api/memory
    ├─ /api/cron/jobs
    ├─ /api/skills
@@ -379,8 +410,9 @@ Check that the Android connection's API key matches `API_SERVER_KEY` from the He
 ### Dashboard screens show empty or error
 
 - Verify the dashboard is running with `--host 0.0.0.0` (an open dashboard also needs `--insecure`).
-- If the dashboard is password-protected, set the username/password under **⋮ → Dashboard Login** (or **Custom dashboard details** when adding the connection). A 401 here means the credentials are wrong.
-- Check the dashboard port matches the connection (default `9119` for local/Tailscale, same HTTPS port for hosted; override it in Dashboard Login if needed).
+- If the dashboard is password-protected, set the username/password under **⋮ → Dashboard / Proxy Settings** (or **Custom proxy and dashboard details** when adding the connection). A 401 here means the credentials are wrong.
+- If the dashboard sits behind a reverse-proxy path, set **Dashboard path prefix**. If the proxy injects dashboard auth, enable **Dashboard behind proxy** so the app sends clean requests.
+- Check the dashboard port matches the connection (default `9119` for local/Tailscale, same HTTPS port for hosted; override it in Dashboard / Proxy Settings if needed).
 - The dashboard must be on the same host as the Gateway API Server for the app's drawer to reach it.
 
 ### Voice dictation or spoken replies aren't working
@@ -404,6 +436,8 @@ hermes-machine.tailnet-name.ts.net
 https://your-hermes-host.example.com
 https://your-hermes-host.example.com:8443
 ```
+
+For hosted paths such as `https://your-hermes-host.example.com/profile/peter`, enter `https://your-hermes-host.example.com` as the host and `/profile/peter` as the **Gateway path prefix**.
 
 ## Project structure
 

--- a/lib/core/models/connection.dart
+++ b/lib/core/models/connection.dart
@@ -60,8 +60,7 @@ class SavedConnection {
   /// dashboard lives on 9119. HTTPS reverse-proxy deployments usually expose
   /// both API surfaces on the same external HTTPS port. An explicit
   /// [dashboardPortOverride] always wins.
-  int get dashboardPort =>
-      dashboardPortOverride ?? (useHttps ? port : 9119);
+  int get dashboardPort => dashboardPortOverride ?? (useHttps ? port : 9119);
 
   /// Joins a base URL with an optional path prefix, normalising slashes.
   static String joinBaseUrl(String baseUrl, String pathPrefix) {
@@ -69,9 +68,7 @@ class SavedConnection {
         ? baseUrl.substring(0, baseUrl.length - 1)
         : baseUrl;
     if (pathPrefix.isNotEmpty) {
-      var prefix = pathPrefix.startsWith('/')
-          ? pathPrefix
-          : '/$pathPrefix';
+      var prefix = pathPrefix.startsWith('/') ? pathPrefix : '/$pathPrefix';
       prefix = prefix.endsWith('/')
           ? prefix.substring(0, prefix.length - 1)
           : prefix;
@@ -190,6 +187,8 @@ class SavedConnection {
     int? dashboardPortOverride,
     String? dashboardUsername,
     String? dashboardPassword,
+    bool clearGatewayPrefix = false,
+    bool clearDashboardPrefix = false,
     bool clearDashboardPort = false,
     bool clearDashboardUsername = false,
     bool clearDashboardPassword = false,
@@ -201,8 +200,12 @@ class SavedConnection {
       port: port ?? this.port,
       apiKey: apiKey ?? this.apiKey,
       useHttps: useHttps ?? this.useHttps,
-      gatewayPrefix: gatewayPrefix ?? this.gatewayPrefix,
-      dashboardPrefix: dashboardPrefix ?? this.dashboardPrefix,
+      gatewayPrefix: clearGatewayPrefix
+          ? null
+          : (gatewayPrefix ?? this.gatewayPrefix),
+      dashboardPrefix: clearDashboardPrefix
+          ? null
+          : (dashboardPrefix ?? this.dashboardPrefix),
       dashboardProxied: dashboardProxied ?? this.dashboardProxied,
       dashboardPortOverride: clearDashboardPort
           ? null

--- a/lib/core/models/connection.dart
+++ b/lib/core/models/connection.dart
@@ -18,6 +18,9 @@ class SavedConnection {
   final int port;
   final String apiKey;
   final bool useHttps;
+  final String? gatewayPrefix;
+  final String? dashboardPrefix;
+  final bool dashboardProxied;
 
   /// Explicit dashboard port. When null, [dashboardPort] falls back to the
   /// default topology (see below). Set this when the dashboard is exposed on a
@@ -39,6 +42,9 @@ class SavedConnection {
     required this.port,
     required this.apiKey,
     this.useHttps = false,
+    this.gatewayPrefix,
+    this.dashboardPrefix,
+    this.dashboardProxied = false,
     this.dashboardPortOverride,
     this.dashboardUsername,
     this.dashboardPassword,
@@ -56,6 +62,23 @@ class SavedConnection {
   /// [dashboardPortOverride] always wins.
   int get dashboardPort =>
       dashboardPortOverride ?? (useHttps ? port : 9119);
+
+  /// Joins a base URL with an optional path prefix, normalising slashes.
+  static String joinBaseUrl(String baseUrl, String pathPrefix) {
+    var url = baseUrl.endsWith('/')
+        ? baseUrl.substring(0, baseUrl.length - 1)
+        : baseUrl;
+    if (pathPrefix.isNotEmpty) {
+      var prefix = pathPrefix.startsWith('/')
+          ? pathPrefix
+          : '/$pathPrefix';
+      prefix = prefix.endsWith('/')
+          ? prefix.substring(0, prefix.length - 1)
+          : prefix;
+      url = '$url$prefix';
+    }
+    return url;
+  }
 
   /// Parses [input] as a URI and extracts host, port, and HTTPS flag.
   ///
@@ -103,7 +126,7 @@ class SavedConnection {
   }
 
   Map<String, dynamic> toMap() {
-    return {
+    final m = <String, dynamic>{
       'id': id,
       'label': label,
       'host': host,
@@ -111,9 +134,23 @@ class SavedConnection {
       'api_key': apiKey,
       'use_https': useHttps,
       'dashboard_port': dashboardPortOverride,
-      'dashboard_username': dashboardUsername,
-      'dashboard_password': dashboardPassword,
     };
+    if (gatewayPrefix != null && gatewayPrefix!.isNotEmpty) {
+      m['gateway_prefix'] = gatewayPrefix;
+    }
+    if (dashboardPrefix != null && dashboardPrefix!.isNotEmpty) {
+      m['dashboard_prefix'] = dashboardPrefix;
+    }
+    if (dashboardProxied) {
+      m['dashboard_proxied'] = dashboardProxied;
+    }
+    if (dashboardUsername != null && dashboardUsername!.isNotEmpty) {
+      m['dashboard_username'] = dashboardUsername;
+    }
+    if (dashboardPassword != null && dashboardPassword!.isNotEmpty) {
+      m['dashboard_password'] = dashboardPassword;
+    }
+    return m;
   }
 
   factory SavedConnection.fromMap(Map<String, dynamic> map) {
@@ -129,6 +166,9 @@ class SavedConnection {
       port: (map['port'] as int?) ?? 8642,
       apiKey: (map['api_key'] as String?) ?? '',
       useHttps: (map['use_https'] as bool?) ?? false,
+      gatewayPrefix: map['gateway_prefix'] as String?,
+      dashboardPrefix: map['dashboard_prefix'] as String?,
+      dashboardProxied: (map['dashboard_proxied'] as bool?) ?? false,
       dashboardPortOverride: map['dashboard_port'] as int?,
       dashboardUsername: nonEmpty(map['dashboard_username']),
       dashboardPassword: nonEmpty(map['dashboard_password']),
@@ -144,6 +184,9 @@ class SavedConnection {
     int? port,
     String? apiKey,
     bool? useHttps,
+    String? gatewayPrefix,
+    String? dashboardPrefix,
+    bool? dashboardProxied,
     int? dashboardPortOverride,
     String? dashboardUsername,
     String? dashboardPassword,
@@ -158,6 +201,9 @@ class SavedConnection {
       port: port ?? this.port,
       apiKey: apiKey ?? this.apiKey,
       useHttps: useHttps ?? this.useHttps,
+      gatewayPrefix: gatewayPrefix ?? this.gatewayPrefix,
+      dashboardPrefix: dashboardPrefix ?? this.dashboardPrefix,
+      dashboardProxied: dashboardProxied ?? this.dashboardProxied,
       dashboardPortOverride: clearDashboardPort
           ? null
           : (dashboardPortOverride ?? this.dashboardPortOverride),

--- a/lib/core/screens/chat_screen.dart
+++ b/lib/core/screens/chat_screen.dart
@@ -60,6 +60,7 @@ class _ChatScreenState extends State<ChatScreen> {
     _client = ApiClient(
       baseUrl: widget.connection.baseUrl,
       apiKey: widget.connection.apiKey,
+      pathPrefix: widget.connection.gatewayPrefix ?? '',
     );
     _gateway = GatewayChatClient(_client);
     _fetchMessages();

--- a/lib/core/screens/cron_screen.dart
+++ b/lib/core/screens/cron_screen.dart
@@ -29,6 +29,8 @@ class _CronScreenState extends State<CronScreen> {
     _client = DashboardClient(
       host: widget.connection.host,
       port: widget.connection.dashboardPort,
+      pathPrefix: widget.connection.dashboardPrefix ?? "",
+      proxied: widget.connection.dashboardProxied,
       useHttps: widget.connection.useHttps,
       username: widget.connection.dashboardUsername,
       password: widget.connection.dashboardPassword,

--- a/lib/core/screens/memory_screen.dart
+++ b/lib/core/screens/memory_screen.dart
@@ -30,6 +30,8 @@ class _MemoryScreenState extends State<MemoryScreen> {
     _client = DashboardClient(
       host: widget.connection.host,
       port: widget.connection.dashboardPort,
+      pathPrefix: widget.connection.dashboardPrefix ?? "",
+      proxied: widget.connection.dashboardProxied,
       useHttps: widget.connection.useHttps,
       username: widget.connection.dashboardUsername,
       password: widget.connection.dashboardPassword,

--- a/lib/core/screens/session_list_screen.dart
+++ b/lib/core/screens/session_list_screen.dart
@@ -28,6 +28,7 @@ class _SessionListScreenState extends State<SessionListScreen> {
     _client = ApiClient(
       baseUrl: widget.connection.baseUrl,
       apiKey: widget.connection.apiKey,
+      pathPrefix: widget.connection.gatewayPrefix ?? '',
     );
     _checkHealth();
   }

--- a/lib/core/screens/settings_screen.dart
+++ b/lib/core/screens/settings_screen.dart
@@ -33,6 +33,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _client = DashboardClient(
       host: widget.connection.host,
       port: widget.connection.dashboardPort,
+      pathPrefix: widget.connection.dashboardPrefix ?? "",
+      proxied: widget.connection.dashboardProxied,
       useHttps: widget.connection.useHttps,
       username: widget.connection.dashboardUsername,
       password: widget.connection.dashboardPassword,

--- a/lib/core/screens/skills_screen.dart
+++ b/lib/core/screens/skills_screen.dart
@@ -22,6 +22,8 @@ class _SkillsScreenState extends State<SkillsScreen> {
     _client = DashboardClient(
       host: widget.connection.host,
       port: widget.connection.dashboardPort,
+      pathPrefix: widget.connection.dashboardPrefix ?? "",
+      proxied: widget.connection.dashboardProxied,
       useHttps: widget.connection.useHttps,
       username: widget.connection.dashboardUsername,
       password: widget.connection.dashboardPassword,

--- a/lib/core/services/connection_manager.dart
+++ b/lib/core/services/connection_manager.dart
@@ -67,13 +67,25 @@ class ConnectionManager {
     int? dashboardPort,
     required String username,
     required String password,
+    String? gatewayPrefix,
+    String? dashboardPrefix,
+    bool? dashboardProxied,
   }) {
     final current = getConnections();
     final idx = current.indexWhere((c) => c.id == connId);
     if (idx < 0) return;
     final u = username.trim();
     final p = password.trim();
+    final gateway = gatewayPrefix?.trim();
+    final dashboard = dashboardPrefix?.trim();
     current[idx] = current[idx].copyWith(
+      gatewayPrefix: gateway == null || gateway.isEmpty ? null : gateway,
+      clearGatewayPrefix: gateway != null && gateway.isEmpty,
+      dashboardPrefix: dashboard == null || dashboard.isEmpty
+          ? null
+          : dashboard,
+      clearDashboardPrefix: dashboard != null && dashboard.isEmpty,
+      dashboardProxied: dashboardProxied,
       dashboardPortOverride: dashboardPort,
       clearDashboardPort: dashboardPort == null,
       dashboardUsername: u.isEmpty ? null : u,
@@ -433,8 +445,11 @@ class GatewayChatClient {
 
 /// Client for the Hermes Dashboard REST API.
 ///
-/// Two auth modes, picked by whether dashboard credentials are supplied:
+/// Three auth modes, picked by proxy configuration and supplied credentials:
 ///
+///  * **Proxied dashboard** — when [proxied] is true, upstream infrastructure
+///    injects auth and the app sends clean JSON requests with no dashboard
+///    session token or cookie.
 ///  * **Password (gated) dashboard** — when [username] and [password] are set,
 ///    performs the `/auth/password-login` flow (provider `basic`) and
 ///    authenticates subsequent `/api/` calls with the returned
@@ -526,7 +541,9 @@ class DashboardClient {
         r'((?:__Host-|__Secure-)?hermes_session_at)=([^;,\s]+)',
       ).firstMatch(setCookie);
       if (match == null) {
-        throw Exception('Dashboard login succeeded but no session cookie found');
+        throw Exception(
+          'Dashboard login succeeded but no session cookie found',
+        );
       }
       _cookie = '${match.group(1)}=${match.group(2)}';
       return _cookie!;
@@ -557,13 +574,10 @@ class DashboardClient {
     }
   }
 
-   Future<Map<String, String>> _authHeaders() async {
+  Future<Map<String, String>> _authHeaders() async {
     if (_proxied) return {'Content-Type': 'application/json'};
     if (_usesPasswordAuth) {
-      return {
-        'Cookie': await _getCookie(),
-        'Content-Type': 'application/json',
-      };
+      return {'Cookie': await _getCookie(), 'Content-Type': 'application/json'};
     }
     return {
       'X-Hermes-Session-Token': await _getToken(),

--- a/lib/core/services/connection_manager.dart
+++ b/lib/core/services/connection_manager.dart
@@ -33,6 +33,9 @@ class ConnectionManager {
     String host,
     int port,
     String apiKey, {
+    String? gatewayPrefix,
+    String? dashboardPrefix,
+    bool dashboardProxied = false,
     int? dashboardPort,
     String? dashboardUsername,
     String? dashboardPassword,
@@ -45,6 +48,9 @@ class ConnectionManager {
       port: normalized.port,
       apiKey: apiKey,
       useHttps: normalized.useHttps,
+      gatewayPrefix: gatewayPrefix,
+      dashboardPrefix: dashboardPrefix,
+      dashboardProxied: dashboardProxied,
       dashboardPortOverride: dashboardPort,
       dashboardUsername: dashboardUsername,
       dashboardPassword: dashboardPassword,
@@ -109,11 +115,10 @@ class ApiClient {
   ApiClient({
     required String baseUrl,
     required String apiKey,
+    String pathPrefix = '',
     http.Client? httpClient,
   }) : _apiKey = apiKey,
-       baseUrl = baseUrl.endsWith('/')
-           ? baseUrl.substring(0, baseUrl.length - 1)
-           : baseUrl,
+       baseUrl = SavedConnection.joinBaseUrl(baseUrl, pathPrefix),
        _http = httpClient ?? http.Client();
 
   Map<String, String> get _headers => {
@@ -443,6 +448,7 @@ class GatewayChatClient {
 class DashboardClient {
   final http.Client _http;
   final String _baseUrl;
+  final bool _proxied;
   final String? _username;
   final String? _password;
   String? _token;
@@ -462,12 +468,18 @@ class DashboardClient {
     required String host,
     int port = 9119,
     bool useHttps = false,
+    String pathPrefix = '',
+    bool proxied = false,
     String? username,
     String? password,
     http.Client? httpClient,
-  }) : _baseUrl = '${useHttps ? 'https' : 'http'}://$host:$port',
+  }) : _proxied = proxied,
        _username = username,
        _password = password,
+       _baseUrl = SavedConnection.joinBaseUrl(
+         '${useHttps ? 'https' : 'http'}://$host:$port',
+         pathPrefix,
+       ),
        _http = httpClient ?? http.Client();
 
   /// Clears any cached auth state so the next request re-authenticates.
@@ -545,7 +557,8 @@ class DashboardClient {
     }
   }
 
-  Future<Map<String, String>> _authHeaders() async {
+   Future<Map<String, String>> _authHeaders() async {
+    if (_proxied) return {'Content-Type': 'application/json'};
     if (_usesPasswordAuth) {
       return {
         'Cookie': await _getCookie(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -203,27 +203,27 @@ class _HomeScreenState extends State<HomeScreen> {
     showDialog(
       context: context,
       builder: (_) => _AddDialog(
-        onSave:
-            (
-              label,
-              host,
-              port,
-              apiKey, {
-              dashboardPort,
-              dashboardUsername,
-              dashboardPassword,
-            }) {
-              widget.connManager.saveConnection(
-                label,
-                host,
-                port,
-                apiKey,
-                dashboardPort: dashboardPort,
-                dashboardUsername: dashboardUsername,
-                dashboardPassword: dashboardPassword,
-              );
-              _refresh();
-            },
+        onSave: (label, host, port, apiKey,
+            {gatewayPrefix,
+            dashboardPrefix,
+            dashboardProxied = false,
+            dashboardPort,
+            dashboardUsername,
+            dashboardPassword}) {
+          widget.connManager.saveConnection(
+            label,
+            host,
+            port,
+            apiKey,
+            gatewayPrefix: gatewayPrefix,
+            dashboardPrefix: dashboardPrefix,
+            dashboardProxied: dashboardProxied,
+            dashboardPort: dashboardPort,
+            dashboardUsername: dashboardUsername,
+            dashboardPassword: dashboardPassword,
+          );
+          _refresh();
+        },
       ),
     );
   }
@@ -509,7 +509,8 @@ class _HomeScreenState extends State<HomeScreen> {
         leading: const Icon(Icons.router, color: Color(0xFFD4AF37)),
         title: Text(conn.label),
         subtitle: Text(
-          '${conn.host}:${conn.port}  \u2022  Key: ${conn.apiKey.isNotEmpty ? "\u2713" : "\u2717"}',
+          '${conn.host}:${conn.port}${conn.gatewayPrefix != null && conn.gatewayPrefix!.isNotEmpty ? conn.gatewayPrefix! : ''}'
+          '  \u2022  Key: ${conn.apiKey.isNotEmpty ? "\u2713" : "\u2717"}',
           style: TextStyle(color: Colors.grey[600]),
         ),
         trailing: PopupMenuButton<String>(
@@ -613,6 +614,9 @@ class _AddDialog extends StatefulWidget {
     String host,
     int port,
     String apiKey, {
+    String? gatewayPrefix,
+    String? dashboardPrefix,
+    bool dashboardProxied,
     int? dashboardPort,
     String? dashboardUsername,
     String? dashboardPassword,
@@ -629,10 +633,13 @@ class _AddDialogState extends State<_AddDialog> {
   final _host = TextEditingController();
   final _port = TextEditingController(text: '8642');
   final _apiKey = TextEditingController();
+  final _gatewayPrefix = TextEditingController();
+  final _dashboardPrefix = TextEditingController();
   final _dashPort = TextEditingController();
   final _dashUser = TextEditingController();
   final _dashPass = TextEditingController();
   bool _showDashboard = false;
+  bool _dashboardProxied = false;
   bool _validating = false;
   String? _error;
 
@@ -722,6 +729,13 @@ class _AddDialogState extends State<_AddDialog> {
         host,
         port,
         apiKey,
+        gatewayPrefix: _gatewayPrefix.text.trim().isEmpty
+            ? null
+            : _gatewayPrefix.text.trim(),
+        dashboardPrefix: _dashboardPrefix.text.trim().isEmpty
+            ? null
+            : _dashboardPrefix.text.trim(),
+        dashboardProxied: _dashboardProxied,
         dashboardPort: dashPort,
         dashboardUsername: dashUser.isEmpty ? null : dashUser,
         dashboardPassword: dashPass.isEmpty ? null : dashPass,
@@ -829,6 +843,32 @@ class _AddDialogState extends State<_AddDialog> {
               ),
             ),
             if (_showDashboard) ...[
+              const SizedBox(height: 8),
+              TextField(
+                controller: _gatewayPrefix,
+                decoration: const InputDecoration(
+                  labelText: 'Gateway path prefix',
+                  hintText: 'e.g. /profile/peter (proxy path before /api/ and /v1/)',
+                ),
+                autocorrect: false,
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _dashboardPrefix,
+                decoration: const InputDecoration(
+                  labelText: 'Dashboard path prefix',
+                  hintText: 'e.g. /dashboard (proxy path before /api/)',
+                ),
+                autocorrect: false,
+              ),
+              const SizedBox(height: 8),
+              SwitchListTile(
+                value: _dashboardProxied,
+                contentPadding: EdgeInsets.zero,
+                title: const Text('Dashboard behind proxy'),
+                subtitle: const Text('Nginx injects auth — app sends clean requests'),
+                onChanged: (v) => setState(() => _dashboardProxied = v),
+              ),
               Padding(
                 padding: const EdgeInsets.only(bottom: 4),
                 child: Text(
@@ -893,6 +933,8 @@ class _AddDialogState extends State<_AddDialog> {
     _host.dispose();
     _port.dispose();
     _apiKey.dispose();
+    _gatewayPrefix.dispose();
+    _dashboardPrefix.dispose();
     _dashPort.dispose();
     _dashUser.dispose();
     _dashPass.dispose();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -203,27 +203,33 @@ class _HomeScreenState extends State<HomeScreen> {
     showDialog(
       context: context,
       builder: (_) => _AddDialog(
-        onSave: (label, host, port, apiKey,
-            {gatewayPrefix,
-            dashboardPrefix,
-            dashboardProxied = false,
-            dashboardPort,
-            dashboardUsername,
-            dashboardPassword}) {
-          widget.connManager.saveConnection(
-            label,
-            host,
-            port,
-            apiKey,
-            gatewayPrefix: gatewayPrefix,
-            dashboardPrefix: dashboardPrefix,
-            dashboardProxied: dashboardProxied,
-            dashboardPort: dashboardPort,
-            dashboardUsername: dashboardUsername,
-            dashboardPassword: dashboardPassword,
-          );
-          _refresh();
-        },
+        onSave:
+            (
+              label,
+              host,
+              port,
+              apiKey, {
+              gatewayPrefix,
+              dashboardPrefix,
+              dashboardProxied = false,
+              dashboardPort,
+              dashboardUsername,
+              dashboardPassword,
+            }) {
+              widget.connManager.saveConnection(
+                label,
+                host,
+                port,
+                apiKey,
+                gatewayPrefix: gatewayPrefix,
+                dashboardPrefix: dashboardPrefix,
+                dashboardProxied: dashboardProxied,
+                dashboardPort: dashboardPort,
+                dashboardUsername: dashboardUsername,
+                dashboardPassword: dashboardPassword,
+              );
+              _refresh();
+            },
       ),
     );
   }
@@ -303,7 +309,11 @@ class _HomeScreenState extends State<HomeScreen> {
 
                       try {
                         final baseUrl = conn.baseUrl;
-                        final client = ApiClient(baseUrl: baseUrl, apiKey: key);
+                        final client = ApiClient(
+                          baseUrl: baseUrl,
+                          apiKey: key,
+                          pathPrefix: conn.gatewayPrefix ?? '',
+                        );
                         final ok = await client.healthCheck();
                         client.close();
 
@@ -345,11 +355,18 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   void _showDashboardAuthDialog(SavedConnection conn) {
+    final gatewayPrefixCtrl = TextEditingController(
+      text: conn.gatewayPrefix ?? '',
+    );
+    final dashboardPrefixCtrl = TextEditingController(
+      text: conn.dashboardPrefix ?? '',
+    );
     final portCtrl = TextEditingController(
       text: conn.dashboardPortOverride?.toString() ?? '',
     );
     final userCtrl = TextEditingController(text: conn.dashboardUsername ?? '');
     final passCtrl = TextEditingController(text: conn.dashboardPassword ?? '');
+    var proxied = conn.dashboardProxied;
     bool validating = false;
     String? error;
 
@@ -357,7 +374,7 @@ class _HomeScreenState extends State<HomeScreen> {
       context: context,
       builder: (ctx) => StatefulBuilder(
         builder: (ctx, setDialogState) => AlertDialog(
-          title: const Text('Dashboard Login'),
+          title: const Text('Dashboard / Proxy Settings'),
           content: SingleChildScrollView(
             child: Column(
               mainAxisSize: MainAxisSize.min,
@@ -365,10 +382,10 @@ class _HomeScreenState extends State<HomeScreen> {
                 Padding(
                   padding: const EdgeInsets.only(bottom: 12),
                   child: Text(
-                    'Used for the Settings, Memory, Skills and Cron tabs. '
-                    'Set the dashboard port and, if the dashboard is '
-                    'password-protected, the username and password. Leave '
-                    'username/password blank for an open (insecure) dashboard.',
+                    'Used for hosted path prefixes and for the Settings, '
+                    'Memory, Skills and Cron tabs. Leave username/password '
+                    'blank for an open dashboard, or enable proxied mode when '
+                    'your reverse proxy injects dashboard auth.',
                     style: TextStyle(color: Colors.grey[600], fontSize: 12),
                   ),
                 ),
@@ -380,21 +397,62 @@ class _HomeScreenState extends State<HomeScreen> {
                     decoration: BoxDecoration(
                       color: Colors.red.withValues(alpha: 0.1),
                       borderRadius: BorderRadius.circular(8),
-                      border: Border.all(color: Colors.red.withValues(alpha: 0.3)),
+                      border: Border.all(
+                        color: Colors.red.withValues(alpha: 0.3),
+                      ),
                     ),
                     child: Row(
                       children: [
-                        const Icon(Icons.error_outline, color: Colors.red, size: 18),
+                        const Icon(
+                          Icons.error_outline,
+                          color: Colors.red,
+                          size: 18,
+                        ),
                         const SizedBox(width: 8),
                         Expanded(
                           child: Text(
                             error!,
-                            style: const TextStyle(color: Colors.red, fontSize: 13),
+                            style: const TextStyle(
+                              color: Colors.red,
+                              fontSize: 13,
+                            ),
                           ),
                         ),
                       ],
                     ),
                   ),
+                TextField(
+                  controller: gatewayPrefixCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'Gateway path prefix',
+                    hintText: 'e.g. /profile/peter',
+                  ),
+                  autocorrect: false,
+                  enabled: !validating,
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: dashboardPrefixCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'Dashboard path prefix',
+                    hintText: 'e.g. /dashboard',
+                  ),
+                  autocorrect: false,
+                  enabled: !validating,
+                ),
+                const SizedBox(height: 8),
+                SwitchListTile(
+                  value: proxied,
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Dashboard behind proxy'),
+                  subtitle: const Text(
+                    'Proxy injects auth; app sends clean requests',
+                  ),
+                  onChanged: validating
+                      ? null
+                      : (v) => setDialogState(() => proxied = v),
+                ),
+                const SizedBox(height: 8),
                 TextField(
                   controller: portCtrl,
                   decoration: const InputDecoration(
@@ -444,16 +502,40 @@ class _HomeScreenState extends State<HomeScreen> {
                       }
                       final user = userCtrl.text.trim();
                       final pass = passCtrl.text.trim();
+                      final gatewayPrefix = gatewayPrefixCtrl.text.trim();
+                      final dashboardPrefix = dashboardPrefixCtrl.text.trim();
 
                       setDialogState(() {
                         validating = true;
                         error = null;
                       });
 
+                      if (gatewayPrefix != (conn.gatewayPrefix ?? '')) {
+                        final apiClient = ApiClient(
+                          baseUrl: conn.baseUrl,
+                          apiKey: conn.apiKey,
+                          pathPrefix: gatewayPrefix,
+                        );
+                        final ok = await apiClient.healthCheck();
+                        apiClient.close();
+                        if (!ctx.mounted) return;
+                        if (!ok) {
+                          setDialogState(() {
+                            error =
+                                'Could not reach/authenticate the Gateway API at '
+                                '${conn.host}:${conn.port}$gatewayPrefix.';
+                            validating = false;
+                          });
+                          return;
+                        }
+                      }
+
                       final client = DashboardClient(
                         host: conn.host,
                         port: port ?? conn.dashboardPort,
                         useHttps: conn.useHttps,
+                        pathPrefix: dashboardPrefix,
+                        proxied: proxied,
                         username: user.isEmpty ? null : user,
                         password: pass.isEmpty ? null : pass,
                       );
@@ -466,6 +548,9 @@ class _HomeScreenState extends State<HomeScreen> {
                           dashboardPort: port,
                           username: user,
                           password: pass,
+                          gatewayPrefix: gatewayPrefix,
+                          dashboardPrefix: dashboardPrefix,
+                          dashboardProxied: proxied,
                         );
                         _refresh();
                         Navigator.pop(ctx);
@@ -496,6 +581,8 @@ class _HomeScreenState extends State<HomeScreen> {
         ),
       ),
     ).whenComplete(() {
+      gatewayPrefixCtrl.dispose();
+      dashboardPrefixCtrl.dispose();
       portCtrl.dispose();
       userCtrl.dispose();
       passCtrl.dispose();
@@ -528,7 +615,7 @@ class _HomeScreenState extends State<HomeScreen> {
             const PopupMenuItem(value: 'apikey', child: Text('Update API Key')),
             const PopupMenuItem(
               value: 'dashboard',
-              child: Text('Dashboard Login'),
+              child: Text('Dashboard / Proxy Settings'),
             ),
             const PopupMenuItem(
               value: 'delete',
@@ -648,6 +735,8 @@ class _AddDialogState extends State<_AddDialog> {
     final host = _host.text.trim();
     final port = int.tryParse(_port.text.trim()) ?? 8642;
     final apiKey = _apiKey.text.trim();
+    final gatewayPrefix = _gatewayPrefix.text.trim();
+    final dashboardPrefix = _dashboardPrefix.text.trim();
 
     if (label.isEmpty || host.isEmpty || port <= 0) return;
 
@@ -666,7 +755,11 @@ class _AddDialogState extends State<_AddDialog> {
         apiKey: '',
         useHttps: normalized.useHttps,
       ).baseUrl;
-      final client = ApiClient(baseUrl: baseUrl, apiKey: apiKey);
+      final client = ApiClient(
+        baseUrl: baseUrl,
+        apiKey: apiKey,
+        pathPrefix: gatewayPrefix,
+      );
       final ok = await client.healthCheck();
       client.close();
 
@@ -690,7 +783,11 @@ class _AddDialogState extends State<_AddDialog> {
       // If the user supplied any dashboard details, validate them before saving
       // (parity with the Dashboard Login dialog). The gateway is already known
       // good at this point.
-      if (dashPortText.isNotEmpty || dashUser.isNotEmpty || dashPass.isNotEmpty) {
+      if (dashPortText.isNotEmpty ||
+          dashUser.isNotEmpty ||
+          dashPass.isNotEmpty ||
+          dashboardPrefix.isNotEmpty ||
+          _dashboardProxied) {
         final dashClient = DashboardClient(
           host: normalized.host,
           port: SavedConnection(
@@ -703,6 +800,8 @@ class _AddDialogState extends State<_AddDialog> {
             dashboardPortOverride: dashPort,
           ).dashboardPort,
           useHttps: normalized.useHttps,
+          pathPrefix: dashboardPrefix,
+          proxied: _dashboardProxied,
           username: dashUser.isEmpty ? null : dashUser,
           password: dashPass.isEmpty ? null : dashPass,
         );
@@ -729,12 +828,8 @@ class _AddDialogState extends State<_AddDialog> {
         host,
         port,
         apiKey,
-        gatewayPrefix: _gatewayPrefix.text.trim().isEmpty
-            ? null
-            : _gatewayPrefix.text.trim(),
-        dashboardPrefix: _dashboardPrefix.text.trim().isEmpty
-            ? null
-            : _dashboardPrefix.text.trim(),
+        gatewayPrefix: gatewayPrefix.isEmpty ? null : gatewayPrefix,
+        dashboardPrefix: dashboardPrefix.isEmpty ? null : dashboardPrefix,
         dashboardProxied: _dashboardProxied,
         dashboardPort: dashPort,
         dashboardUsername: dashUser.isEmpty ? null : dashUser,
@@ -835,7 +930,7 @@ class _AddDialogState extends State<_AddDialog> {
                     ),
                     const SizedBox(width: 4),
                     Text(
-                      'Custom dashboard details',
+                      'Custom proxy and dashboard details',
                       style: TextStyle(color: Colors.grey[500], fontSize: 13),
                     ),
                   ],
@@ -848,7 +943,8 @@ class _AddDialogState extends State<_AddDialog> {
                 controller: _gatewayPrefix,
                 decoration: const InputDecoration(
                   labelText: 'Gateway path prefix',
-                  hintText: 'e.g. /profile/peter (proxy path before /api/ and /v1/)',
+                  hintText:
+                      'e.g. /profile/peter (proxy path before /api/ and /v1/)',
                 ),
                 autocorrect: false,
               ),
@@ -866,7 +962,9 @@ class _AddDialogState extends State<_AddDialog> {
                 value: _dashboardProxied,
                 contentPadding: EdgeInsets.zero,
                 title: const Text('Dashboard behind proxy'),
-                subtitle: const Text('Nginx injects auth — app sends clean requests'),
+                subtitle: const Text(
+                  'Nginx injects auth — app sends clean requests',
+                ),
                 onChanged: (v) => setState(() => _dashboardProxied = v),
               ),
               Padding(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hermes_android
 description: "Hermes Agent — chat with your Hermes Gateway API Server over LAN. SSE streaming, Bearer auth, session management."
 publish_to: 'none'
-version: 1.0.7+107
+version: 1.0.8+108
 
 environment:
   sdk: ^3.12.0

--- a/test/connection_manager_test.dart
+++ b/test/connection_manager_test.dart
@@ -134,24 +134,27 @@ void main() {
       expect(https.dashboardPort, 8443);
     });
 
-    test('round-trips dashboard port and credentials through toMap/fromMap', () {
-      final conn = SavedConnection(
-        id: '1',
-        label: 'Home',
-        host: '192.168.1.50',
-        port: 8642,
-        apiKey: 'key',
-        dashboardPortOverride: 30433,
-        dashboardUsername: 'misha',
-        dashboardPassword: 'secret',
-      );
+    test(
+      'round-trips dashboard port and credentials through toMap/fromMap',
+      () {
+        final conn = SavedConnection(
+          id: '1',
+          label: 'Home',
+          host: '192.168.1.50',
+          port: 8642,
+          apiKey: 'key',
+          dashboardPortOverride: 30433,
+          dashboardUsername: 'misha',
+          dashboardPassword: 'secret',
+        );
 
-      final restored = SavedConnection.fromMap(conn.toMap());
-      expect(restored.dashboardPortOverride, 30433);
-      expect(restored.dashboardUsername, 'misha');
-      expect(restored.dashboardPassword, 'secret');
-      expect(restored.dashboardPort, 30433);
-    });
+        final restored = SavedConnection.fromMap(conn.toMap());
+        expect(restored.dashboardPortOverride, 30433);
+        expect(restored.dashboardUsername, 'misha');
+        expect(restored.dashboardPassword, 'secret');
+        expect(restored.dashboardPort, 30433);
+      },
+    );
 
     test('fromMap is backward compatible with maps lacking dashboard keys', () {
       final restored = SavedConnection.fromMap({
@@ -188,6 +191,9 @@ void main() {
         host: '192.168.1.50',
         port: 8642,
         apiKey: 'key',
+        gatewayPrefix: '/profile/peter',
+        dashboardPrefix: '/dashboard',
+        dashboardProxied: true,
         dashboardPortOverride: 30433,
         dashboardUsername: 'misha',
         dashboardPassword: 'secret',
@@ -195,15 +201,23 @@ void main() {
 
       final keyOnly = conn.copyWith(apiKey: 'new-key');
       expect(keyOnly.apiKey, 'new-key');
+      expect(keyOnly.gatewayPrefix, '/profile/peter');
+      expect(keyOnly.dashboardPrefix, '/dashboard');
+      expect(keyOnly.dashboardProxied, isTrue);
       expect(keyOnly.dashboardPortOverride, 30433);
       expect(keyOnly.dashboardUsername, 'misha');
       expect(keyOnly.dashboardPassword, 'secret');
 
       final cleared = conn.copyWith(
+        clearGatewayPrefix: true,
+        clearDashboardPrefix: true,
         clearDashboardPort: true,
         clearDashboardUsername: true,
         clearDashboardPassword: true,
       );
+      expect(cleared.gatewayPrefix, isNull);
+      expect(cleared.dashboardPrefix, isNull);
+      expect(cleared.dashboardProxied, isTrue);
       expect(cleared.dashboardPortOverride, isNull);
       expect(cleared.dashboardUsername, isNull);
       expect(cleared.dashboardPassword, isNull);
@@ -324,49 +338,52 @@ void main() {
       });
     });
 
-    test('logs in and authenticates /api calls with the session cookie', () async {
-      var loginCalls = 0;
-      final client = DashboardClient(
-        host: 'hermes.local',
-        port: 30433,
-        username: 'misha',
-        password: 'secret',
-        httpClient: MockClient((request) async {
-          if (request.url.path == '/auth/password-login') {
-            loginCalls++;
-            expect(request.method, 'POST');
-            expect(jsonDecode(request.body), {
-              'provider': 'basic',
-              'username': 'misha',
-              'password': 'secret',
-            });
-            return http.Response(
-              '{"ok":true}',
-              200,
-              headers: {
-                'set-cookie':
-                    'hermes_session_at=TOK123; Path=/; HttpOnly; SameSite=Lax',
-              },
-            );
-          }
-          if (request.url.path == '/api/model/info') {
-            // Cookie auth, not the insecure token header.
-            expect(_header(request, 'cookie'), 'hermes_session_at=TOK123');
-            expect(_header(request, 'x-hermes-session-token'), isNull);
-            return http.Response('{"model":"hermes-agent"}', 200);
-          }
-          return http.Response('not found', 404);
-        }),
-      );
+    test(
+      'logs in and authenticates /api calls with the session cookie',
+      () async {
+        var loginCalls = 0;
+        final client = DashboardClient(
+          host: 'hermes.local',
+          port: 30433,
+          username: 'misha',
+          password: 'secret',
+          httpClient: MockClient((request) async {
+            if (request.url.path == '/auth/password-login') {
+              loginCalls++;
+              expect(request.method, 'POST');
+              expect(jsonDecode(request.body), {
+                'provider': 'basic',
+                'username': 'misha',
+                'password': 'secret',
+              });
+              return http.Response(
+                '{"ok":true}',
+                200,
+                headers: {
+                  'set-cookie':
+                      'hermes_session_at=TOK123; Path=/; HttpOnly; SameSite=Lax',
+                },
+              );
+            }
+            if (request.url.path == '/api/model/info') {
+              // Cookie auth, not the insecure token header.
+              expect(_header(request, 'cookie'), 'hermes_session_at=TOK123');
+              expect(_header(request, 'x-hermes-session-token'), isNull);
+              return http.Response('{"model":"hermes-agent"}', 200);
+            }
+            return http.Response('not found', 404);
+          }),
+        );
 
-      final info = await client.getModelInfo();
-      expect(info['model'], 'hermes-agent');
+        final info = await client.getModelInfo();
+        expect(info['model'], 'hermes-agent');
 
-      // A second call reuses the cached cookie (no re-login).
-      await client.getModelInfo();
-      expect(loginCalls, 1);
-      client.close();
-    });
+        // A second call reuses the cached cookie (no re-login).
+        await client.getModelInfo();
+        expect(loginCalls, 1);
+        client.close();
+      },
+    );
 
     test('falls back to homepage token scrape when no credentials', () async {
       final client = DashboardClient(
@@ -405,8 +422,11 @@ void main() {
           if (request.url.path == '/auth/password-login') {
             loginCalls++;
             final cookie = 'hermes_session_at=TOK$loginCalls';
-            return http.Response('{"ok":true}', 200,
-                headers: {'set-cookie': '$cookie; Path=/'});
+            return http.Response(
+              '{"ok":true}',
+              200,
+              headers: {'set-cookie': '$cookie; Path=/'},
+            );
           }
           if (request.url.path == '/api/model/info') {
             apiCalls++;
@@ -478,18 +498,34 @@ void main() {
 
       mgr.updateDashboardAuth(
         id,
+        gatewayPrefix: '/profile/peter',
+        dashboardPrefix: '/dashboard',
+        dashboardProxied: true,
         dashboardPort: 30433,
         username: 'misha',
         password: 'secret',
       );
       var conn = mgr.getConnections().single;
+      expect(conn.gatewayPrefix, '/profile/peter');
+      expect(conn.dashboardPrefix, '/dashboard');
+      expect(conn.dashboardProxied, isTrue);
       expect(conn.dashboardPortOverride, 30433);
       expect(conn.dashboardUsername, 'misha');
       expect(conn.dashboardPassword, 'secret');
 
       // Blank values clear the corresponding fields.
-      mgr.updateDashboardAuth(id, username: '', password: '');
+      mgr.updateDashboardAuth(
+        id,
+        gatewayPrefix: '',
+        dashboardPrefix: '',
+        dashboardProxied: false,
+        username: '',
+        password: '',
+      );
       conn = mgr.getConnections().single;
+      expect(conn.gatewayPrefix, isNull);
+      expect(conn.dashboardPrefix, isNull);
+      expect(conn.dashboardProxied, isFalse);
       expect(conn.dashboardPortOverride, isNull);
       expect(conn.dashboardUsername, isNull);
       expect(conn.dashboardPassword, isNull);
@@ -528,7 +564,10 @@ void main() {
 
     test('joinBaseUrl appends prefix between base and API path', () {
       expect(
-        SavedConnection.joinBaseUrl('https://hermes.example.com:443', '/profile/peter'),
+        SavedConnection.joinBaseUrl(
+          'https://hermes.example.com:443',
+          '/profile/peter',
+        ),
         'https://hermes.example.com:443/profile/peter',
       );
     });
@@ -562,7 +601,10 @@ void main() {
         pathPrefix: '/dashboard',
         proxied: true,
         httpClient: MockClient((request) async {
-          expect(request.headers.containsKey('x-hermes-session-token'), isFalse);
+          expect(
+            request.headers.containsKey('x-hermes-session-token'),
+            isFalse,
+          );
           expect(request.headers.containsKey('cookie'), isFalse);
           return http.Response('{"data": {}}', 200);
         }),
@@ -571,24 +613,30 @@ void main() {
       client.close();
     });
 
-    test('DashboardClient proxied ignores credentials, sends clean headers', () async {
-      final client = DashboardClient(
-        host: 'hermes.example.com',
-        port: 443,
-        useHttps: true,
-        pathPrefix: '/dashboard',
-        proxied: true,
-        username: 'user',
-        password: 'pass',
-        httpClient: MockClient((request) async {
-          expect(request.headers.containsKey('x-hermes-session-token'), isFalse);
-          expect(request.headers.containsKey('cookie'), isFalse);
-          return http.Response('{"data": {}}', 200);
-        }),
-      );
-      await client.apiGet('model/info');
-      client.close();
-    });
+    test(
+      'DashboardClient proxied ignores credentials, sends clean headers',
+      () async {
+        final client = DashboardClient(
+          host: 'hermes.example.com',
+          port: 443,
+          useHttps: true,
+          pathPrefix: '/dashboard',
+          proxied: true,
+          username: 'user',
+          password: 'pass',
+          httpClient: MockClient((request) async {
+            expect(
+              request.headers.containsKey('x-hermes-session-token'),
+              isFalse,
+            );
+            expect(request.headers.containsKey('cookie'), isFalse);
+            return http.Response('{"data": {}}', 200);
+          }),
+        );
+        await client.apiGet('model/info');
+        client.close();
+      },
+    );
 
     test('SavedConnection serializes gateway and dashboard prefixes', () {
       final conn = SavedConnection(

--- a/test/connection_manager_test.dart
+++ b/test/connection_manager_test.dart
@@ -517,4 +517,95 @@ void main() {
       expect(conn.dashboardPassword, 'secret');
     });
   });
+
+  group('Path prefix support', () {
+    test('joinBaseUrl without prefix returns baseUrl unchanged', () {
+      expect(
+        SavedConnection.joinBaseUrl('https://hermes.example.com:443', ''),
+        'https://hermes.example.com:443',
+      );
+    });
+
+    test('joinBaseUrl appends prefix between base and API path', () {
+      expect(
+        SavedConnection.joinBaseUrl('https://hermes.example.com:443', '/profile/peter'),
+        'https://hermes.example.com:443/profile/peter',
+      );
+    });
+
+    test('ApiClient pathPrefix is prepended to baseUrl', () {
+      final client = ApiClient(
+        baseUrl: 'https://hermes.example.com:443',
+        apiKey: 'key',
+        pathPrefix: '/profile/peter',
+      );
+      expect(client.baseUrl, 'https://hermes.example.com:443/profile/peter');
+      client.close();
+    });
+
+    test('DashboardClient uses pathPrefix', () {
+      final client = DashboardClient(
+        host: 'hermes.example.com',
+        port: 443,
+        useHttps: true,
+        pathPrefix: '/dashboard',
+      );
+      expect(client.baseUrl, 'https://hermes.example.com:443/dashboard');
+      client.close();
+    });
+
+    test('DashboardClient proxied sends no auth headers', () async {
+      final client = DashboardClient(
+        host: 'hermes.example.com',
+        port: 443,
+        useHttps: true,
+        pathPrefix: '/dashboard',
+        proxied: true,
+        httpClient: MockClient((request) async {
+          expect(request.headers.containsKey('x-hermes-session-token'), isFalse);
+          expect(request.headers.containsKey('cookie'), isFalse);
+          return http.Response('{"data": {}}', 200);
+        }),
+      );
+      await client.apiGet('model/info');
+      client.close();
+    });
+
+    test('DashboardClient proxied ignores credentials, sends clean headers', () async {
+      final client = DashboardClient(
+        host: 'hermes.example.com',
+        port: 443,
+        useHttps: true,
+        pathPrefix: '/dashboard',
+        proxied: true,
+        username: 'user',
+        password: 'pass',
+        httpClient: MockClient((request) async {
+          expect(request.headers.containsKey('x-hermes-session-token'), isFalse);
+          expect(request.headers.containsKey('cookie'), isFalse);
+          return http.Response('{"data": {}}', 200);
+        }),
+      );
+      await client.apiGet('model/info');
+      client.close();
+    });
+
+    test('SavedConnection serializes gateway and dashboard prefixes', () {
+      final conn = SavedConnection(
+        id: '1',
+        label: 'Proxy',
+        host: 'hermes.example.com',
+        port: 443,
+        apiKey: 'key',
+        useHttps: true,
+        gatewayPrefix: '/profile/peter',
+        dashboardPrefix: '/dashboard',
+        dashboardProxied: true,
+      );
+      final map = conn.toMap();
+      expect(map['gateway_prefix'], '/profile/peter');
+      expect(map['dashboard_prefix'], '/dashboard');
+      expect(map['dashboard_proxied'], true);
+    });
+  });
 }


### PR DESCRIPTION
Adds support for Hermes deployments behind a reverse proxy where the
Gateway API and Dashboard share the same host/port but sit under
different URL paths (e.g. `/profile/peter/v1/` for chat,
`/dashboard/api/` for dashboard).

### Changes

- **`SavedConnection`**: new fields `gatewayPrefix`, `dashboardPrefix`,
  and `dashboardProxied` to configure custom API paths and proxy mode.

- **`joinBaseUrl()`**: normalizes a base URL with an optional path
  prefix, used by both `ApiClient` and `DashboardClient`.

- **`ApiClient`**: accepts optional `pathPrefix` parameter so all REST
  calls (sessions, messages, health, chat completions) go through the
  correct proxy path.

- **`DashboardClient`**: accepts `pathPrefix` and `proxied` parameters.
  When `proxied` is true, skips SPA session-token auto-discovery and
  sends clean HTTP requests — the proxy injects `Authorization: Bearer`.

- **UI**: adds an "Advanced / Proxy Settings" collapsible section to
  the connection dialog with fields for gateway path prefix, dashboard
  path prefix, and a "Dashboard behind proxy" toggle.
