### PR TITLE
fix: remember and restore scroll position per session

### DIFF
--- a/lib/core/screens/chat_screen.dart
+++ b/lib/core/screens/chat_screen.dart
@@ -53,6 +53,8 @@ class _ChatScreenState extends State<ChatScreen> {
   // Scroll management
   final _scrollController = ScrollController();
   bool _showScrollToBottom = false;
+  double _lastPixels = 0;
+  static final Map<String, double> _savedPositions = {};
 
   @override
   void initState() {
@@ -76,6 +78,7 @@ class _ChatScreenState extends State<ChatScreen> {
 
   @override
   void dispose() {
+    _savedPositions[widget.session.id] = _lastPixels;
     _speechToText.cancel();
     _flutterTts.stop();
     _client.close();
@@ -191,6 +194,9 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   void _onScroll() {
+    if (_scrollController.hasClients) {
+      _lastPixels = _scrollController.position.pixels;
+    }
     final atBottom =
         _scrollController.hasClients &&
         _scrollController.position.pixels >=
@@ -223,7 +229,24 @@ class _ChatScreenState extends State<ChatScreen> {
         _messages = messages;
         _loading = false;
       });
-      _scrollToBottom();
+      final saved = _savedPositions[widget.session.id];
+      if (saved != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (_scrollController.hasClients) {
+            _scrollController.jumpTo(
+              saved.clamp(0.0, _scrollController.position.maxScrollExtent),
+            );
+          }
+        });
+      } else {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (_scrollController.hasClients) {
+            _scrollController.jumpTo(
+              _scrollController.position.maxScrollExtent,
+            );
+          }
+        });
+      }
     } catch (e) {
       if (!mounted) return;
       final errStr = e.toString();
@@ -309,7 +332,24 @@ class _ChatScreenState extends State<ChatScreen> {
               await _speakAssistantText(assistantText);
             }
           }
-          _scrollToBottom();
+          final saved = _savedPositions[widget.session.id];
+      if (saved != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (_scrollController.hasClients) {
+            _scrollController.jumpTo(
+              saved.clamp(0.0, _scrollController.position.maxScrollExtent),
+            );
+          }
+        });
+      } else {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (_scrollController.hasClients) {
+            _scrollController.jumpTo(
+              _scrollController.position.maxScrollExtent,
+            );
+          }
+        });
+      }
         } catch (e) {
           setState(() {
             _streaming = false;


### PR DESCRIPTION
When leaving and re-entering a chat session, the scroll position is
now restored to where the user was, instead of always jumping to the
bottom (or top, since `_scrollToBottom()` fired before the ListView
was laid out).

### Changes

**`_lastPixels`** — tracks the last known scroll position, updated in
`_onScroll()` on every scroll event. Storing in `dispose()` was
unreliable because `hasClients` is already false when the widget tree
tears down.

**`_savedPositions`** — a static map (`sessionId → pixels`) shared
across `ChatScreen` instances so returning to the same session
restores the previous scroll offset.

**`_fetchMessages()`** — if a saved position exists for the session,
uses `WidgetsBinding.instance.addPostFrameCallback` to `jumpTo()` the
saved offset after layout completes. On first visit, scrolls to the
bottom as before.