### PR TITLE
fix: render multimodal session content safely

### DIFF
--- a/lib/core/screens/chat_screen.dart
+++ b/lib/core/screens/chat_screen.dart
@@ -10,6 +10,7 @@ import 'package:speech_to_text/speech_recognition_result.dart';
 import 'package:speech_to_text/speech_to_text.dart';
 
 import '../services/connection_manager.dart';
+import '../utils/message_content.dart';
 import '../utils/responsive.dart';
 
 class ChatScreen extends StatefulWidget {
@@ -295,7 +296,7 @@ class _ChatScreenState extends State<ChatScreen> {
           (msg['toolCallName'] as String?) ??
           '';
       final toolCallId = (msg['tool_call_id'] as String?) ?? '';
-      final content = (msg['content'] as String?) ?? '';
+      final content = messageContentToText(msg['content']);
 
       String toolName = name.isNotEmpty ? name : '';
       if (toolName.isEmpty && content.isNotEmpty) {
@@ -687,7 +688,7 @@ class _ChatScreenState extends State<ChatScreen> {
         continue;
       }
       if (role != 'user' && role != 'assistant') continue;
-      final content = (msg['content'] as String?) ?? '';
+      final content = messageContentToText(msg['content']);
       if (content.isEmpty) continue;
 
       if (currentGroup.isNotEmpty) {
@@ -719,7 +720,7 @@ class _ChatScreenState extends State<ChatScreen> {
 
         final msg = item as Map<String, dynamic>;
         final role = (msg['role'] as String?) ?? 'assistant';
-        final content = (msg['content'] as String?) ?? '';
+        final content = messageContentToText(msg['content']);
         final isUser = role == 'user';
 
         return _MessageBubble(

--- a/lib/core/utils/message_content.dart
+++ b/lib/core/utils/message_content.dart
@@ -1,0 +1,37 @@
+/// Convert Hermes/OpenAI message content into displayable text.
+///
+/// Legacy messages carry a String. Multimodal messages carry a list of typed
+/// parts such as `{type: text, text: ...}` and `{type: image_url, ...}`.
+/// Keep rendering resilient when the gateway adds new part types.
+String messageContentToText(dynamic content) {
+  if (content == null) return '';
+  if (content is String) return content;
+
+  if (content is List) {
+    return content
+        .map(_contentPartToText)
+        .where((part) => part.isNotEmpty)
+        .join('\n\n');
+  }
+
+  return _contentPartToText(content);
+}
+
+String _contentPartToText(dynamic part) {
+  if (part == null) return '';
+  if (part is String) return part;
+  if (part is! Map) return part.toString();
+
+  final text = part['text'];
+  if (text is String && text.isNotEmpty) return text;
+
+  final type = part['type']?.toString() ?? 'unknown';
+  if (type.contains('image') || part.containsKey('image_url')) {
+    return '[Image]';
+  }
+  if (type.contains('file') || part.containsKey('file')) {
+    return '[File]';
+  }
+
+  return '[Unsupported content: $type]';
+}

--- a/test/message_content_test.dart
+++ b/test/message_content_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hermes_android/core/utils/message_content.dart';
+
+void main() {
+  group('messageContentToText', () {
+    test('keeps legacy string content unchanged', () {
+      expect(messageContentToText('hello'), 'hello');
+    });
+
+    test('joins OpenAI text content parts', () {
+      expect(
+        messageContentToText([
+          {'type': 'text', 'text': 'first'},
+          {'type': 'text', 'text': 'second'},
+        ]),
+        'first\n\nsecond',
+      );
+    });
+
+    test('renders mixed text and image content without throwing', () {
+      expect(
+        messageContentToText([
+          {'type': 'text', 'text': 'caption'},
+          {
+            'type': 'image_url',
+            'image_url': {'url': 'https://example.invalid/image.png'},
+          },
+        ]),
+        'caption\n\n[Image]',
+      );
+    });
+
+    test('handles null and unknown structured content safely', () {
+      expect(messageContentToText(null), '');
+      expect(
+        messageContentToText([
+          {'type': 'custom_part', 'payload': 42},
+        ]),
+        '[Unsupported content: custom_part]',
+      );
+    });
+  });
+}


### PR DESCRIPTION
> **Agent disclosure:** This change was prepared, tested, and submitted by Metis, an AI coding agent, acting on behalf of @ruben2000de. Ruben authorized the contribution and validated the fix on his Pixel 8a.

## Bug Description

Opening a session that contains OpenAI-style multipart message content shows a blank/white chat screen instead of rendering the conversation.

ADB logcat reports:

```text
type 'List<dynamic>' is not a subtype of type 'String?' in type cast
#0 _ChatScreenState._buildBody (chat_screen.dart:690)
```

## Root Cause

`ChatScreen` cast every message's `content` field directly to `String?`. Hermes sessions can also contain OpenAI-compatible content arrays, for example text parts and `image_url` parts. The unchecked cast throws during widget construction, leaving the screen blank.

## Fix

- Add `messageContentToText` to normalize both legacy string content and multipart content arrays.
- Preserve text parts and render image/file parts as safe placeholders.
- Render unknown structured parts as an explicit placeholder instead of crashing the whole chat view.
- Use the normalizer for user/assistant bubbles, filtering, and tool-message extraction.
- Add regression coverage for strings, text arrays, mixed text/image content, nulls, and unknown parts.

## How to Verify

1. Connect the Android client to a Hermes gateway.
2. Open a session containing a message whose `content` is a list with `text` and/or `image_url` parts.
3. Confirm the session renders instead of showing a blank screen.

## Test Plan

- [x] Added regression tests for legacy and multipart content.
- [x] `flutter analyze --fatal-infos` — no issues found.
- [x] `flutter test` — all 37 tests passed.
- [x] Manually reproduced on a Pixel 8a with the v1.0.9 APK, then verified the same session renders in the patched side-by-side build.
- [x] Checked ADB logcat after opening the affected session; no Flutter exception remains.

## Maintainer Notes

- Review scope is intentionally small: one commit, three files.
- No dependency, configuration, storage, API, or migration changes.
- Maintainer edits are enabled on the source branch.
- GitHub Actions is awaiting the standard first-time fork-contributor approval; the same analyze/test commands have already passed locally.

## Risk Assessment

Low — the change is isolated to display-time conversion of message content. Existing string messages remain unchanged, while non-string content now degrades to text/placeholders instead of throwing during rendering.
