### PR TITLE
feat: session source filter in Settings (checkbox-style)

### DIFF
--- a/lib/core/screens/session_list_screen.dart
+++ b/lib/core/screens/session_list_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../services/connection_manager.dart';
 import 'chat_screen.dart';
 import 'settings_screen.dart';
@@ -54,8 +55,14 @@ class _SessionListScreenState extends State<SessionListScreen> {
     try {
       final sessions = await _client.getSessions();
       if (!mounted) return;
+      final prefs = await SharedPreferences.getInstance();
+      final key = 'excluded_session_sources_${widget.connection.id}';
+      final excluded = prefs.getStringList(key) ?? [];
+      final filtered =
+          sessions.where((s) => !excluded.contains(s.source)).toList();
+      if (!mounted) return;
       setState(() {
-        _sessions = sessions;
+        _sessions = filtered;
         _loading = false;
       });
     } catch (e) {

--- a/lib/core/screens/settings_screen.dart
+++ b/lib/core/screens/settings_screen.dart
@@ -322,6 +322,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
         _VoicePicker(),
         const SizedBox(height: 16),
 
+        // ---- Section: Session Sources ----
+        _buildSectionHeader('Session Sources'),
+        _SessionSourcesFilter(connectionId: widget.connection.id),
+        const SizedBox(height: 16),
+
         // ---- Section: Connection ----
         _buildSectionHeader('Connection'),
         Card(
@@ -690,6 +695,90 @@ class _VoicePickerState extends State<_VoicePicker> {
       ),
       items: items,
       onChanged: _set,
+    );
+  }
+}
+
+/// Checkbox list of session sources. Unchecked sources are filtered
+/// client-side from the fetched session list by `Session.source`.
+class _SessionSourcesFilter extends StatefulWidget {
+  final String connectionId;
+  const _SessionSourcesFilter({required this.connectionId});
+
+  @override
+  State<_SessionSourcesFilter> createState() => _SessionSourcesFilterState();
+}
+
+class _SessionSourcesFilterState extends State<_SessionSourcesFilter> {
+  /// Known session source types. Hermes Gateway persists `session.source` for
+  /// every session. Sources not in this list are always shown (whitelisted).
+  static const Map<String, String> _knownSources = {
+    'acp': 'Autonomous agents',
+    'api_server': 'External API clients',
+    'cli': 'Command-line chats',
+    'cron': 'Scheduled tasks',
+    'desktop': 'Desktop app',
+    'discord': 'Discord chats',
+    'gateway': 'Gateway API access',
+    'mobile': 'Phone or tablet',
+    'signal': 'Signal messages',
+    'slack': 'Slack chats',
+    'telegram': 'Telegram messages',
+    'tool': 'Developer tool calls',
+    'tui': 'Terminal sessions',
+    'whatsapp': 'WhatsApp messages',
+  };
+
+  Set<String> _excluded = {};
+
+  String get _prefsKey =>
+      'excluded_session_sources_${widget.connectionId}';
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    setState(() {
+      _excluded =
+          prefs.getStringList(_prefsKey)?.toSet() ?? {};
+    });
+  }
+
+  Future<void> _toggle(String source, bool enabled) async {
+    final prefs = await SharedPreferences.getInstance();
+    setState(() {
+      if (enabled) {
+        _excluded.remove(source);
+      } else {
+        _excluded.add(source);
+      }
+    });
+    await prefs.setStringList(_prefsKey, _excluded.toList());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Column(
+        children: _knownSources.entries.map((entry) {
+          final source = entry.key;
+          final label = entry.value;
+          final isVisible = !_excluded.contains(source);
+          return CheckboxListTile(
+            title: Text(label),
+            subtitle: Text(source,
+                style: const TextStyle(fontSize: 12, color: Colors.grey)),
+            value: isVisible,
+            onChanged: (val) => _toggle(source, val ?? true),
+            dense: true,
+            controlAffinity: ListTileControlAffinity.leading,
+          );
+        }).toList(),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Problem

The Android session list shows all Hermes sessions including scheduled tasks and developer tool calls, making it noisy for mobile users who only want their chat conversations.

## Solution

Checkbox-style source filter in Settings. Each session origin type gets a checkbox (checked = visible). Unchecked sources are filtered **client-side** from the fetched session list by `Session.source` — no backend API changes needed.

## Changes

**2 files, +98/-2:**

- **lib/core/screens/settings_screen.dart** — New `_SessionSourcesFilter` widget with 14 known source types, each with a plain-English label. Lives in a "Session Sources" section below Voice, above Connection. Preference key is scoped by connection ID so multi-gateway users don't bleed settings.
- **lib/core/screens/session_list_screen.dart** — After fetching sessions, reads the excluded list from SharedPreferences and filters client-side. Re-reads prefs on every refresh so changes from Settings take effect immediately.

**connection_manager.dart** intentionally unchanged — filtering is entirely client-side.

## Design

- **Checked = visible** — intuitive semantics
- **Empty default** = show everything (backward compatible)
- **Connection-scoped key** — `excluded_session_sources_<connection.id>`
- **Unknown sources whitelisted** — not in the known list = always shown
- **Plain-English labels** — "Scheduled tasks", "Signal messages", "Phone or tablet" — not internal source keys
- Same SharedPreferences pattern as existing `_VerboseToggle` and `_ThemeToggle`

## Sources covered

acp (Autonomous agents), api_server, cli, cron (Scheduled tasks), desktop, discord, gateway, mobile, signal, slack, telegram, tool, tui, whatsapp