### PR TITLE
fix: bump Android app version to 1.0.13

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -41,6 +41,26 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
+      - name: Verify tag matches app version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PUBSPEC_VERSION=$(python3 - <<'PY'
+          import pathlib
+          import re
+
+          match = re.search(r"^version:\\s*([^+\\s]+)", pathlib.Path("pubspec.yaml").read_text(), re.M)
+          if not match:
+              raise SystemExit("pubspec.yaml is missing a version line")
+          print(match.group(1))
+          PY
+          )
+
+          if [ "$TAG_VERSION" != "$PUBSPEC_VERSION" ]; then
+            echo "Release tag v$TAG_VERSION does not match pubspec.yaml version $PUBSPEC_VERSION"
+            exit 1
+          fi
+
       - name: Set up release keystore
         env:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Release notes for
 versions prior to 1.0.7 are in the **What's new** sections of the [README](README.md).
 
+## [1.0.13]
+
+### Changed
+- Updated the Flutter package version to `1.0.13+113` so generated Android
+  builds report the same version as the GitHub `v1.0.13` release.
+
 ## [1.0.12]
 
 ### Added

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hermes_android
 description: "Hermes Agent — chat with your Hermes Gateway API Server over LAN. SSE streaming, Bearer auth, session management."
 publish_to: 'none'
-version: 1.0.12+112
+version: 1.0.13+113
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
Addresses issue #79.

## Summary
- Updates `pubspec.yaml` from `1.0.12+112` to `1.0.13+113` so generated Android builds report the same version as the existing `v1.0.13` GitHub release.
- Adds a `1.0.13` changelog note for the version metadata correction.
- Adds a release workflow guard that fails tag builds when the Git tag version does not match `pubspec.yaml`, preventing repeat mismatched APK releases.

## Verification
- `flutter test` -> 42 tests passed.
- Local release-version guard check: `GITHUB_REF_NAME=v1.0.13` passes, `GITHUB_REF_NAME=v1.0.14` fails against `pubspec.yaml` version `1.0.13` as expected.