### PR TITLE
fix: remove hardcoded desktop gateway URL default and allow clearing optional fields

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -876,7 +876,7 @@ class _AddDialogState extends State<_AddDialog> {
     _dashUser = TextEditingController(text: conn?.dashboardUsername ?? '');
     _dashPass = TextEditingController(text: conn?.dashboardPassword ?? '');
     _desktopGatewayUrl = TextEditingController(
-      text: conn?.desktopGatewayUrl ?? 'http://192.168.1.193/desktop',
+      text: conn?.desktopGatewayUrl ?? '',
     );
     _dashboardProxied = conn?.dashboardProxied ?? false;
     _showDashboard =
@@ -988,10 +988,10 @@ class _AddDialogState extends State<_AddDialog> {
         host,
         port,
         apiKey,
-        gatewayPrefix: gatewayPrefix.isEmpty ? null : gatewayPrefix,
-        dashboardPrefix: dashboardPrefix.isEmpty ? null : dashboardPrefix,
+        gatewayPrefix: gatewayPrefix,
+        dashboardPrefix: dashboardPrefix,
         dashboardProxied: _dashboardProxied,
-        desktopGatewayUrl: desktopGatewayUrl.isEmpty ? null : desktopGatewayUrl,
+        desktopGatewayUrl: desktopGatewayUrl,
         dashboardPort: dashPort,
         dashboardUsername: dashUser.isEmpty ? null : dashUser,
         dashboardPassword: dashPass.isEmpty ? null : dashPass,


### PR DESCRIPTION
## Summary

Fixes two bugs in the connection add/edit dialog that made the Desktop
Gateway URL field effectively unmanageable. This matters because, per #84,
stock Hermes always falls back to legacy REST — reaching a clean REST setup
is the only practical path, and these bugs block it.

### 1. Hardcoded default

`_AddDialog` defaulted "Desktop Gateway URL" to a hardcoded developer IP
(`http://192.168.1.193/desktop`) instead of empty, so a fresh connection
pre-filled a bogus URL.

### 2. Un-clearable fields

`_validateAndSave` converted empty optional fields (`gatewayPrefix`,
`dashboardPrefix`, `desktopGatewayUrl`) to `null` before saving, but
`updateConnection`'s `clear*` flags (in `connection_manager.dart`) require a
**non-null empty string** to detect a clear. With `null` passed, `copyWith`'s
`null ?? oldValue` kept the previous value, so these fields silently reverted
to their last value on every edit.

## Changes

`lib/main.dart` only — pass the raw (possibly empty) value through instead of
null-coalescing it, and default the desktop gateway field text to empty.

## Verification

Built and installed locally; confirmed the "Desktop Gateway URL" field now
defaults to empty and can be cleared on an existing connection, allowing the
app to fall back to REST chat against a stock Hermes gateway.

## Related

- #84 — Remote Gateway transport never activates against stock Hermes; this
  fix makes the documented REST fallback reachable without a working Desktop
  Gateway.