### PR TITLE
fix: resync legacy turns after app resume

### DIFF
--- a/lib/core/screens/chat_screen.dart
+++ b/lib/core/screens/chat_screen.dart
@@ -196,6 +196,8 @@ class _ChatScreenState extends State<ChatScreen> with WidgetsBindingObserver {
   String? _activeClientTurnId;
   bool _recoveringTurn = false;
   bool _legacyTransportFallback = false;
+  bool _legacyResumeSyncPending = false;
+  bool _legacyResumeSyncInFlight = false;
   int _responseGeneration = 0;
   bool _approvalDialogOpen = false;
   final List<_PendingSensitivePrompt> _sensitivePromptQueue = [];
@@ -352,6 +354,9 @@ class _ChatScreenState extends State<ChatScreen> with WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.paused) {
       _appInBackground = true;
+      if (_legacyTransportFallback && (_sending || _streaming)) {
+        _legacyResumeSyncPending = true;
+      }
     } else if (state == AppLifecycleState.resumed) {
       _appInBackground = false;
       unawaited(_turnNotifications.cancelAll());
@@ -359,6 +364,41 @@ class _ChatScreenState extends State<ChatScreen> with WidgetsBindingObserver {
       if (_turnApplicationSession != null && !_legacyTransportFallback) {
         unawaited(_recoverPendingTurn());
       }
+      _scheduleLegacyResumeSyncIfIdle();
+    }
+  }
+
+  void _scheduleLegacyResumeSyncIfIdle() {
+    if (!mounted ||
+        !_legacyTransportFallback ||
+        !_legacyResumeSyncPending ||
+        _legacyResumeSyncInFlight ||
+        _appInBackground ||
+        _sending ||
+        _streaming) {
+      return;
+    }
+    _legacyResumeSyncPending = false;
+    unawaited(_resyncLegacyMessages());
+  }
+
+  Future<void> _resyncLegacyMessages() async {
+    _legacyResumeSyncInFlight = true;
+    try {
+      final messages = await _client.getMessages(widget.session.id);
+      if (!mounted) return;
+      _extractToolMessages(messages);
+      setState(() {
+        _messages = messages;
+        _error = null;
+      });
+      _scheduleInitialEndAlignment();
+    } catch (_) {
+      // Keep the usable local chat when a resume-time refresh is transiently
+      // unavailable. A later legacy turn can schedule another refresh.
+    } finally {
+      _legacyResumeSyncInFlight = false;
+      _scheduleLegacyResumeSyncIfIdle();
     }
   }
 
@@ -1700,6 +1740,7 @@ class _ChatScreenState extends State<ChatScreen> with WidgetsBindingObserver {
         _gatewayTurnStatus = null;
         _activeResponseTransport = _ResponseTransport.none;
       });
+      _scheduleLegacyResumeSyncIfIdle();
       _scheduleScrollTarget(_scrollCoordinator.endStreaming());
       if (_awaitingVoiceReply) {
         _awaitingVoiceReply = false;
@@ -2433,6 +2474,7 @@ class _ChatScreenState extends State<ChatScreen> with WidgetsBindingObserver {
         ),
       );
     }
+    _scheduleLegacyResumeSyncIfIdle();
   }
 
   void _upsertToolProgress(

--- a/test/chat_turn_recovery_test.dart
+++ b/test/chat_turn_recovery_test.dart
@@ -198,6 +198,102 @@ void main() {
   );
 
   testWidgets(
+    'legacy fallback resyncs a turn that completes while backgrounded',
+    (tester) async {
+      final session = _FakeTurnSession(
+        const <Object>[],
+        recoverError: const GatewayTurnCoordinatorException(
+          GatewayTurnCoordinatorFailure.unsupportedCapability,
+        ),
+      );
+      final legacySubmit = Completer<void>();
+      final httpClient = _LegacyResumeChatHttpClient();
+      await _pumpChat(
+        tester,
+        turnSession: session,
+        httpClient: httpClient,
+        testRemotePromptSubmit:
+            ({required sessionId, required text, required onEvent}) =>
+                legacySubmit.future,
+      );
+
+      await tester.enterText(find.byType(TextField), 'Legacy in background');
+      await tester.tap(find.byTooltip('Send'));
+      await tester.pump();
+      for (final state in const <AppLifecycleState>[
+        AppLifecycleState.inactive,
+        AppLifecycleState.hidden,
+        AppLifecycleState.paused,
+      ]) {
+        tester.binding.handleAppLifecycleStateChanged(state);
+      }
+      await tester.pump();
+
+      legacySubmit.complete();
+      await tester.pumpAndSettle();
+      expect(httpClient.messageRequestCount, 1);
+      expect(find.text('Completed while backgrounded'), findsNothing);
+
+      for (final state in const <AppLifecycleState>[
+        AppLifecycleState.hidden,
+        AppLifecycleState.inactive,
+        AppLifecycleState.resumed,
+      ]) {
+        tester.binding.handleAppLifecycleStateChanged(state);
+      }
+      await tester.pumpAndSettle();
+
+      expect(httpClient.messageRequestCount, 2);
+      expect(find.text('Completed while backgrounded'), findsOneWidget);
+    },
+  );
+
+  testWidgets('legacy resume waits for the active stream before resyncing', (
+    tester,
+  ) async {
+    final session = _FakeTurnSession(
+      const <Object>[],
+      recoverError: const GatewayTurnCoordinatorException(
+        GatewayTurnCoordinatorFailure.unsupportedCapability,
+      ),
+    );
+    final legacySubmit = Completer<void>();
+    final httpClient = _LegacyResumeChatHttpClient();
+    await _pumpChat(
+      tester,
+      turnSession: session,
+      httpClient: httpClient,
+      testRemotePromptSubmit:
+          ({required sessionId, required text, required onEvent}) =>
+              legacySubmit.future,
+    );
+
+    await tester.enterText(find.byType(TextField), 'Legacy in background');
+    await tester.tap(find.byTooltip('Send'));
+    await tester.pump();
+    for (final state in const <AppLifecycleState>[
+      AppLifecycleState.inactive,
+      AppLifecycleState.hidden,
+      AppLifecycleState.paused,
+      AppLifecycleState.hidden,
+      AppLifecycleState.inactive,
+      AppLifecycleState.resumed,
+    ]) {
+      tester.binding.handleAppLifecycleStateChanged(state);
+    }
+    await tester.pump();
+
+    expect(httpClient.messageRequestCount, 1);
+    expect(find.text('Legacy in background'), findsOneWidget);
+
+    legacySubmit.complete();
+    await tester.pumpAndSettle();
+
+    expect(httpClient.messageRequestCount, 2);
+    expect(find.text('Completed while backgrounded'), findsOneWidget);
+  });
+
+  testWidgets(
     'network auth malformed and unsafe journal errors never enable legacy',
     (tester) async {
       final errors = <Object>[
@@ -305,6 +401,7 @@ void main() {
 Future<void> _pumpChat(
   WidgetTester tester, {
   required _FakeTurnSession turnSession,
+  http.BaseClient? httpClient,
   TestRemotePromptSubmit? testRemotePromptSubmit,
   TestRemoteAttachmentUpload? testRemoteAttachmentUpload,
   AttachmentDraftService? attachmentDraftService,
@@ -313,7 +410,7 @@ Future<void> _pumpChat(
   final apiClient = ApiClient(
     baseUrl: 'http://recovery.fixture',
     apiKey: 'synthetic-key',
-    httpClient: _EmptyChatHttpClient(),
+    httpClient: httpClient ?? _EmptyChatHttpClient(),
   );
   await tester.pumpWidget(
     MaterialApp(
@@ -496,6 +593,33 @@ class _EmptyChatHttpClient extends http.BaseClient {
     if (request.method == 'GET' && request.url.path.endsWith('/messages')) {
       return http.StreamedResponse(
         Stream.value(utf8.encode(jsonEncode({'data': <Object>[]}))),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+    return http.StreamedResponse(
+      Stream.value(utf8.encode(jsonEncode({'error': 'unexpected request'}))),
+      404,
+      headers: {'content-type': 'application/json'},
+    );
+  }
+}
+
+class _LegacyResumeChatHttpClient extends http.BaseClient {
+  int messageRequestCount = 0;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    if (request.method == 'GET' && request.url.path.endsWith('/messages')) {
+      messageRequestCount += 1;
+      final messages = messageRequestCount == 1
+          ? const <Object>[]
+          : const <Object>[
+              {'role': 'user', 'content': 'Legacy in background'},
+              {'role': 'assistant', 'content': 'Completed while backgrounded'},
+            ];
+      return http.StreamedResponse(
+        Stream.value(utf8.encode(jsonEncode({'data': messages}))),
         200,
         headers: {'content-type': 'application/json'},
       );


### PR DESCRIPTION
## Summary

Legacy fallback chats now restore a reply that completes while Android is backgrounded instead of requiring the user to leave and reopen the chat. The app records only backgrounded active legacy turns, waits until streaming settles, and then silently refreshes the authoritative session history once.

The refresh is guarded against overlapping calls and keeps the usable local chat when a resume-time request fails. Server-side `turn_recovery` capability negotiation remains unchanged.

## Validation

- Added lifecycle coverage for a legacy turn that completes while backgrounded.
- Added coverage that resume waits for an active legacy stream before refreshing.
- `flutter test --no-pub`: 299 tests passed.
- `flutter analyze --no-pub --fatal-infos`: no issues found.
- Physical-device validation is pending because no Android device was connected to the build host.

Related: #84

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
