### PR TITLE
Add configurable Android mTLS transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ v2.0.0 merges the community Remote Gateway edition from
 - **Messaging-style UI** — dark/light/system themes, gold Hermes accent color (`#D4AF37`), markdown rendering, relative timestamps, and responsive phone/tablet layouts.
 - **Gold/black Hermes branding** — distinctive gold accent on black background, custom app icon with mipmap densities, agent messages use grey bubbles.
 - **Gateway API integration** — sessions and chat run through the Hermes Gateway API Server, normally on port `8642`, with HTTP and HTTPS endpoints supported. Reverse-proxy deployments can set a gateway path prefix that is applied before `/api` and `/v1` routes.
-- **Dashboard integrations** — Memory, Cron Jobs, Skills, and Settings screens use the Hermes dashboard API (default port `9119`, configurable per connection) on the same host. Works with open (`--insecure`) dashboards, **password-protected dashboards** via the built-in login, and proxied dashboards where auth is injected upstream.
+- **Dashboard integrations** — Memory, Cron Jobs, Skills, and Settings screens use the Hermes dashboard API (default port `9119`, or a separate configurable URL). Works with open (`--insecure`) dashboards, **password-protected dashboards** via the built-in login, proxied dashboards where auth is injected upstream, and the connection's selected mTLS certificate.
 - **Model settings** — view and change the configured Hermes model where the dashboard exposes model settings.
 - **Cron management** — list, trigger, pause/resume, create, edit, and delete scheduled Hermes cron jobs.
 - **Skills browser** — view available Hermes skills with descriptions and trigger conditions.
@@ -204,12 +204,17 @@ the app's **Dashboard / Proxy Settings** dialog (see [Dashboard access](#4-optio
 4. Tap **+** to add a connection.
 5. Enter:
    - **Label:** any name, e.g. `Home`
-   - **Host:** the host IP, e.g. `192.168.1.50`
-   - **Port:** `8642`
+   - **Host:** the HTTPS URL of the host or reverse proxy
+   - **Port:** the HTTPS port, usually `443`
    - **API Key:** `API_SERVER_KEY` from the Hermes machine
-6. If your deployment is behind a reverse proxy path, expand **Custom proxy and dashboard details** and set the gateway/dashboard prefixes there. Do not put URL paths in the Host field; the Host field is just the scheme, hostname, and optional port.
-7. Tap the saved connection to browse sessions.
-8. Tap a session to start chatting, or create a new one.
+6. Optional: enable **mTLS** and select a client certificate installed in
+   Android. mTLS requires an explicit `https://` Host and protects Gateway REST,
+   SSE, configured dashboard REST calls, and the Desktop Gateway WebSocket.
+   Authenticated connections require HTTPS even when mTLS is off. HTTP remains
+   available only for endpoints that do not send credentials.
+7. If your deployment is behind a reverse proxy path, expand **Custom proxy and dashboard details** and set the gateway/dashboard prefixes there. Do not put URL paths in the Host field; the Host field is just the scheme, hostname, and optional port.
+8. Tap the saved connection to browse sessions.
+9. Tap a session to start chatting, or create a new one.
 
 ### 4. Optional: configure dashboard access
 
@@ -225,6 +230,10 @@ afterwards:
      and `/v1` routes, e.g. `/profile/peter`.
    - **Dashboard path prefix** — optional reverse-proxy path before dashboard
      `/api` routes, e.g. `/dashboard`.
+   - **Dashboard URL** — optional full dashboard origin when it differs from
+     the Gateway, e.g. `https://hermesdb.example.com:42848`. An mTLS-enabled
+     connection uses the selected certificate for this URL too. If the URL
+     omits its port, the separate **Dashboard Port** value is used.
    - **Dashboard behind proxy** — enable this when the proxy injects dashboard
      authentication and the app should not fetch a dashboard SPA token or log in
      with username/password.
@@ -232,7 +241,15 @@ afterwards:
      same external port for HTTPS deployments), or set an explicit port if your
      dashboard is exposed elsewhere.
    - **Username / Password** — only for a password-protected dashboard. Leave
-     both blank for an open (`--insecure`) dashboard.
+     both blank for an open (`--insecure`) dashboard. Password authentication
+     requires HTTPS so credentials are never sent in cleartext.
+   - **Desktop Gateway URL** — optional origin exposing the Desktop JSON-RPC
+     `/api/ws` endpoint for multiple images and arbitrary file attachments.
+     An mTLS-enabled connection uses the selected certificate for both its
+     authentication request and secure WebSocket. Open dashboards reuse their
+     SPA token; authenticated or proxied dashboards mint a one-use ticket.
+     This URL always requires HTTPS because those credentials travel during
+     WebSocket setup.
 3. Tap **Save**. The app validates the settings against the dashboard before
    storing them.
 
@@ -281,8 +298,9 @@ You can also enable MagicDNS and use the machine name instead of the `100.x.y.z`
 
 In the Android app connection dialog:
 
-- **Host:** the Hermes machine Tailscale IP, e.g. `100.64.12.34`, or its MagicDNS name
-- **Port:** `8642`
+- **Host:** an HTTPS reverse-proxy URL routed to the Hermes machine over
+  Tailscale
+- **Port:** the reverse proxy's HTTPS port
 - **API Key:** `API_SERVER_KEY`
 
 If using Memory/Cron/Skills/Settings remotely, keep the dashboard reachable on the same Tailscale host at port `9119`.
@@ -321,7 +339,8 @@ dashboard routes such as
 - Prefer Tailscale/VPN for remote use.
 - Do not port-forward the Gateway API Server or dashboard directly to the public internet.
 - Rotate `API_SERVER_KEY` if it is shared or exposed.
-- Local/Tailscale examples use HTTP, so the private network boundary matters. Use HTTPS for public or hosted endpoints.
+- The app refuses to transmit API keys, dashboard passwords, or Desktop Gateway
+  session credentials over cleartext HTTP/WebSocket connections.
 
 ## Architecture
 
@@ -496,7 +515,8 @@ Check that the Android connection's API key matches `API_SERVER_KEY` from the He
 - If the dashboard is password-protected, set the username/password under **⋮ → Dashboard / Proxy Settings** (or **Custom proxy and dashboard details** when adding the connection). A 401 here means the credentials are wrong.
 - If the dashboard sits behind a reverse-proxy path, set **Dashboard path prefix**. If the proxy injects dashboard auth, enable **Dashboard behind proxy** so the app sends clean requests.
 - Check the dashboard port matches the connection (default `9119` for local/Tailscale, same HTTPS port for hosted; override it in Dashboard / Proxy Settings if needed).
-- The dashboard must be on the same host as the Gateway API Server for the app's drawer to reach it.
+- Set **Dashboard URL** when the dashboard uses a different hostname or port
+  from the Gateway. For mTLS connections it must use `https://`.
 
 ### Voice dictation or spoken replies aren't working
 
@@ -542,6 +562,7 @@ lib/
 │   ├── services/
 │   │   ├── attachment_draft_service.dart # Cache, sanitization, limits, upload order
 │   │   ├── connection_manager.dart    # Saved connections, Gateway API, Dashboard API
+│   │   ├── mtls_client.dart            # Android KeyChain-backed Gateway/dashboard HTTPS transport
 │   │   └── ws_client.dart             # JSON-RPC WebSocket client for future dashboard/TUI use
 │   └── utils/
 │       └── responsive.dart            # Phone/tablet breakpoints

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -96,4 +96,5 @@ android.applicationVariants.configureEach {
 
 dependencies {
    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
+   implementation("com.squareup.okhttp3:okhttp:4.12.0")
 }

--- a/android/app/src/main/kotlin/com/hermesagent/hermes_android/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hermesagent/hermes_android/MainActivity.kt
@@ -1,5 +1,26 @@
 package com.hermesagent.hermes_android
 
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    private var mtlsBridge: MtlsBridge? = null
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        mtlsBridge?.detach()
+        mtlsBridge = MtlsBridge(this, flutterEngine.dartExecutor.binaryMessenger)
+    }
+
+    override fun cleanUpFlutterEngine(flutterEngine: FlutterEngine) {
+        mtlsBridge?.detach()
+        mtlsBridge = null
+        super.cleanUpFlutterEngine(flutterEngine)
+    }
+
+    override fun onDestroy() {
+        mtlsBridge?.detach()
+        mtlsBridge = null
+        super.onDestroy()
+    }
+}

--- a/android/app/src/main/kotlin/com/hermesagent/hermes_android/MtlsBridge.kt
+++ b/android/app/src/main/kotlin/com/hermesagent/hermes_android/MtlsBridge.kt
@@ -1,0 +1,946 @@
+package com.hermesagent.hermes_android
+
+import android.app.Activity
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.security.KeyChain
+import android.security.KeyChainAliasCallback
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.EventChannel
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import java.io.IOException
+import java.io.InterruptedIOException
+import java.lang.ref.WeakReference
+import java.net.Socket
+import java.net.SocketTimeoutException
+import java.security.KeyStore
+import java.security.Principal
+import java.security.PrivateKey
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.net.ssl.KeyManager
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.SSLException
+import javax.net.ssl.SSLHandshakeException
+import javax.net.ssl.SSLPeerUnverifiedException
+import javax.net.ssl.TrustManager
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509ExtendedKeyManager
+import javax.net.ssl.X509TrustManager
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.RequestBody.Companion.toRequestBody
+import okio.ByteString
+
+internal class MtlsBridge(
+    activity: Activity,
+    messenger: BinaryMessenger,
+) : MethodChannel.MethodCallHandler, EventChannel.StreamHandler {
+    private val activityReference = WeakReference(activity)
+    private val context: Context = activity.applicationContext
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val ioExecutor = Executors.newCachedThreadPool()
+    private val requests = ConcurrentHashMap<String, RequestState>()
+    private val webSockets = ConcurrentHashMap<String, WebSocketState>()
+    private val methodChannel = MethodChannel(messenger, METHOD_CHANNEL)
+    private val eventChannel = EventChannel(messenger, EVENT_CHANNEL)
+
+    @Volatile private var eventSink: EventChannel.EventSink? = null
+    @Volatile private var detached = false
+    @Volatile private var chooserResult: MethodChannel.Result? = null
+    private val eventReadyResults = mutableListOf<MethodChannel.Result>()
+
+    init {
+        methodChannel.setMethodCallHandler(this)
+        eventChannel.setStreamHandler(this)
+    }
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "chooseCertificate" -> chooseCertificate(call, result)
+            "describeCertificate" -> describeCertificate(call, result)
+            "waitUntilEventStreamReady" -> waitUntilEventStreamReady(result)
+            "startRequest" -> startRequest(call, result)
+            "cancelRequest" -> cancelRequest(call, result)
+            "startWebSocket" -> startWebSocket(call, result)
+            "sendWebSocket" -> sendWebSocket(call, result)
+            "closeWebSocket" -> closeWebSocket(call, result)
+            "close" -> {
+                cancelAll(emitEvents = true)
+                closeAllWebSockets(emitEvents = true)
+                result.success(null)
+            }
+            else -> result.notImplemented()
+        }
+    }
+
+    override fun onListen(arguments: Any?, events: EventChannel.EventSink) {
+        eventSink = events
+        val readyResults = synchronized(eventReadyResults) {
+            val results = eventReadyResults.toList()
+            eventReadyResults.clear()
+            results
+        }
+        readyResults.forEach { it.success(null) }
+    }
+
+    override fun onCancel(arguments: Any?) {
+        eventSink = null
+    }
+
+    private fun waitUntilEventStreamReady(result: MethodChannel.Result) {
+        if (detached) {
+            result.error("activity_detached", "The secure transport is unavailable.", null)
+            return
+        }
+        if (eventSink != null) {
+            result.success(null)
+            return
+        }
+        synchronized(eventReadyResults) {
+            if (eventSink != null) {
+                result.success(null)
+            } else {
+                eventReadyResults.add(result)
+            }
+        }
+    }
+
+    fun detach() {
+        if (detached) return
+        detached = true
+        chooserResult?.error("activity_detached", "Certificate selection was interrupted.", null)
+        chooserResult = null
+        val readyResults = synchronized(eventReadyResults) {
+            val results = eventReadyResults.toList()
+            eventReadyResults.clear()
+            results
+        }
+        readyResults.forEach {
+            it.error("activity_detached", "The secure transport is unavailable.", null)
+        }
+        cancelAll(emitEvents = false)
+        closeAllWebSockets(emitEvents = false)
+        methodChannel.setMethodCallHandler(null)
+        eventChannel.setStreamHandler(null)
+        eventSink = null
+        ioExecutor.shutdownNow()
+        activityReference.clear()
+    }
+
+    private fun chooseCertificate(call: MethodCall, result: MethodChannel.Result) {
+        if (call.arguments != null && call.arguments !is Map<*, *>) {
+            result.error("invalid_arguments", "Invalid certificate chooser arguments.", null)
+            return
+        }
+        val arguments = call.arguments as? Map<*, *> ?: emptyMap<Any?, Any?>()
+        val hostValue = arguments["host"]
+        val portValue = arguments["port"]
+        val aliasValue = arguments["alias"]
+        if ((hostValue != null && (hostValue !is String || hostValue.isBlank())) ||
+            (portValue != null && (portValue !is Int || portValue !in 1..65535)) ||
+            (aliasValue != null && (aliasValue !is String || aliasValue.isBlank()))
+        ) {
+            result.error("invalid_arguments", "Invalid certificate chooser arguments.", null)
+            return
+        }
+        val currentActivity = activityReference.get()
+        if (currentActivity == null || currentActivity.isFinishing || detached) {
+            result.error("activity_unavailable", "Certificate selection is unavailable.", null)
+            return
+        }
+        if (chooserResult != null) {
+            result.error("chooser_active", "A certificate chooser is already active.", null)
+            return
+        }
+
+        chooserResult = result
+        val callback = ChooserCallback(this)
+        try {
+            KeyChain.choosePrivateKeyAlias(
+                currentActivity,
+                callback,
+                arrayOf("RSA", "EC"),
+                null,
+                hostValue as String?,
+                (portValue as Int?) ?: -1,
+                aliasValue as String?,
+            )
+        } catch (_: RuntimeException) {
+            chooserResult = null
+            result.error("chooser_unavailable", "Certificate selection could not be opened.", null)
+        }
+    }
+
+    private fun onAliasChosen(alias: String?) {
+        if (detached || chooserResult == null) return
+        if (alias == null) {
+            runOnMain { finishChooser(null) }
+            return
+        }
+        ioExecutor.execute {
+            val description = certificateDescription(alias) ?: aliasDescription(alias)
+            runOnMain { finishChooser(description) }
+        }
+    }
+
+    private fun finishChooser(value: Map<String, String>?) {
+        val result = chooserResult ?: return
+        chooserResult = null
+        if (!detached) result.success(value)
+    }
+
+    private fun describeCertificate(call: MethodCall, result: MethodChannel.Result) {
+        val alias =
+            when (val arguments = call.arguments) {
+                is String -> arguments
+                is Map<*, *> -> arguments["alias"]
+                else -> null
+            }
+        if (alias !is String || alias.isBlank()) {
+            result.error("invalid_arguments", "A non-empty alias is required.", null)
+            return
+        }
+        ioExecutor.execute {
+            val description = certificateDescription(alias)
+            runOnMain {
+                if (!detached) result.success(description)
+            }
+        }
+    }
+
+    private fun certificateDescription(alias: String): Map<String, String>? =
+        try {
+            val leaf = KeyChain.getCertificateChain(context, alias)?.firstOrNull() ?: return null
+            val label = leaf.subjectX500Principal?.name?.takeIf { it.isNotBlank() } ?: alias
+            mapOf("alias" to alias, "label" to label)
+        } catch (_: Exception) {
+            null
+        }
+
+    private fun aliasDescription(alias: String) = mapOf("alias" to alias, "label" to alias)
+
+    private fun startRequest(call: MethodCall, result: MethodChannel.Result) {
+        val arguments = call.arguments as? Map<*, *>
+        val requestId = arguments?.get("requestId")
+        val alias = arguments?.get("alias")
+        val methodValue = arguments?.get("method")
+        val urlValue = arguments?.get("url")
+        val headersValue = arguments?.get("headers")
+        val bodyValue = arguments?.get("body")
+
+        if (requestId !is String || requestId.isBlank() ||
+            alias !is String || alias.isBlank() ||
+            methodValue !is String || methodValue.isBlank() ||
+            urlValue !is String ||
+            headersValue !is Map<*, *> ||
+            (bodyValue != null && bodyValue !is ByteArray)
+        ) {
+            result.error("invalid_arguments", "Invalid mTLS request arguments.", null)
+            return
+        }
+        val url = urlValue.toHttpUrlOrNull()
+        if (url == null || url.scheme != "https") {
+            result.error("invalid_arguments", "The request URL must use HTTPS.", null)
+            return
+        }
+        val headers = LinkedHashMap<String, String>()
+        for ((name, value) in headersValue) {
+            if (name !is String || value !is String) {
+                result.error("invalid_arguments", "Headers must contain only string values.", null)
+                return
+            }
+            headers[name] = value
+        }
+        val method = methodValue.uppercase(Locale.US)
+        val body = bodyValue as ByteArray?
+        if ((method == "GET" || method == "HEAD") && body != null) {
+            result.error("invalid_arguments", "$method requests cannot contain a body.", null)
+            return
+        }
+        val requestBody =
+            when {
+                body != null -> body.toRequestBody()
+                method in METHODS_REQUIRING_BODY -> ByteArray(0).toRequestBody()
+                else -> null
+            }
+        val request =
+            try {
+                Request.Builder().url(url).apply {
+                    headers.forEach { (name, value) -> addHeader(name, value) }
+                }.method(method, requestBody).build()
+            } catch (_: IllegalArgumentException) {
+                result.error("invalid_arguments", "The HTTP method or headers are invalid.", null)
+                return
+            }
+
+        val state = RequestState(requestId, result)
+        if (requests.putIfAbsent(requestId, state) != null) {
+            result.error("duplicate_request", "That request ID is already active.", null)
+            return
+        }
+
+        ioExecutor.execute {
+            try {
+                val keyManager = AliasKeyManager.load(context, alias)
+                    ?: throw CertificateUnavailableException()
+                val trustManager = systemTrustManager()
+                val sslContext = SSLContext.getInstance("TLS").apply {
+                    init(
+                        arrayOf<KeyManager>(keyManager),
+                        arrayOf<TrustManager>(trustManager),
+                        SecureRandom(),
+                    )
+                }
+                val client = OkHttpClient.Builder()
+                    .sslSocketFactory(sslContext.socketFactory, trustManager)
+                    .followRedirects(false)
+                    .build()
+                val okHttpCall = client.newCall(request)
+                state.client = client
+                state.call = okHttpCall
+                if (state.cancelled.get() || detached) {
+                    okHttpCall.cancel()
+                    failRequest(state, "request_cancelled", "Request cancelled.")
+                    return@execute
+                }
+                okHttpCall.enqueue(RequestCallback(state))
+            } catch (_: CertificateUnavailableException) {
+                failRequest(state, "certificate_unavailable", "The selected certificate is unavailable.")
+            } catch (_: Exception) {
+                failRequest(state, "request_failed", "The secure request could not be started.")
+            }
+        }
+    }
+
+    private fun cancelRequest(call: MethodCall, result: MethodChannel.Result) {
+        val requestId =
+            when (val arguments = call.arguments) {
+                is String -> arguments
+                is Map<*, *> -> arguments["requestId"]
+                else -> null
+            }
+        if (requestId !is String || requestId.isBlank()) {
+            result.error("invalid_arguments", "A non-empty request ID is required.", null)
+            return
+        }
+        val state = requests.remove(requestId)
+        if (state != null) {
+            state.cancel()
+            completeStartError(state, "request_cancelled", "Request cancelled.")
+            emitError(state, "Request cancelled.")
+            state.cleanup()
+        }
+        result.success(state != null)
+    }
+
+    private fun cancelAll(emitEvents: Boolean) {
+        requests.entries.toList().forEach { (requestId, state) ->
+            if (requests.remove(requestId, state)) {
+                state.cancel()
+                completeStartError(state, "request_cancelled", "Request cancelled.")
+                if (emitEvents) emitError(state, "Request cancelled.")
+                state.cleanup()
+            }
+        }
+    }
+
+        private fun startWebSocket(call: MethodCall, result: MethodChannel.Result) {
+            val arguments = call.arguments as? Map<*, *>
+            val socketId = arguments?.get("socketId")
+            val alias = arguments?.get("alias")
+            val urlValue = arguments?.get("url")
+            if (socketId !is String || socketId.isBlank() ||
+                alias !is String || alias.isBlank() ||
+                urlValue !is String || !urlValue.startsWith("wss://", ignoreCase = true)
+            ) {
+                result.error("invalid_arguments", "Invalid mTLS WebSocket arguments.", null)
+                return
+            }
+            val request =
+                try {
+                    Request.Builder().url(urlValue).build()
+                } catch (_: IllegalArgumentException) {
+                    result.error("invalid_arguments", "The WebSocket URL is invalid.", null)
+                    return
+                }
+            val state = WebSocketState(socketId, result)
+            if (webSockets.putIfAbsent(socketId, state) != null) {
+                result.error("duplicate_websocket", "That WebSocket ID is already active.", null)
+                return
+            }
+
+            ioExecutor.execute {
+                try {
+                    val client = secureClient(alias)
+                    if (!state.attachClient(client)) {
+                        failWebSocketStart(
+                            state,
+                            "request_cancelled",
+                            "WebSocket connection cancelled.",
+                        )
+                        return@execute
+                    }
+                    val socket = client.newWebSocket(request, SecureWebSocketListener(state))
+                    state.socket = socket
+                    if (state.cancelled.get() || detached) {
+                        socket.cancel()
+                        failWebSocketStart(state, "request_cancelled", "WebSocket connection cancelled.")
+                    }
+                } catch (_: CertificateUnavailableException) {
+                    failWebSocketStart(
+                        state,
+                        "certificate_unavailable",
+                        "The selected certificate is unavailable.",
+                    )
+                } catch (_: Exception) {
+                    failWebSocketStart(
+                        state,
+                        "websocket_failed",
+                        "The secure WebSocket could not be started.",
+                    )
+                }
+            }
+        }
+
+        private fun sendWebSocket(call: MethodCall, result: MethodChannel.Result) {
+            val arguments = call.arguments as? Map<*, *>
+            val socketId = arguments?.get("socketId")
+            val data = arguments?.get("data")
+            if (socketId !is String || socketId.isBlank() || data !is String) {
+                result.error("invalid_arguments", "Invalid WebSocket message arguments.", null)
+                return
+            }
+            val state = webSockets[socketId]
+            if (state == null || !state.opened.get() || state.terminal.get()) {
+                result.error("websocket_unavailable", "The secure WebSocket is not connected.", null)
+                return
+            }
+            val sent =
+                try {
+                    state.socket?.send(data) == true
+                } catch (_: RuntimeException) {
+                    false
+                }
+            result.success(sent)
+        }
+
+        private fun closeWebSocket(call: MethodCall, result: MethodChannel.Result) {
+            val arguments = call.arguments as? Map<*, *>
+            val socketId = arguments?.get("socketId")
+            val code = arguments?.get("code")
+            val reason = arguments?.get("reason")
+            if (socketId !is String || socketId.isBlank() ||
+                code !is Int || reason !is String
+            ) {
+                result.error("invalid_arguments", "Invalid WebSocket close arguments.", null)
+                return
+            }
+            val state = webSockets[socketId]
+            if (state == null) {
+                result.success(null)
+                return
+            }
+            if (!state.opened.get()) {
+                state.cancelled.set(true)
+                state.socket?.cancel()
+                failWebSocketStart(
+                    state,
+                    "request_cancelled",
+                    "WebSocket connection cancelled.",
+                )
+                result.success(null)
+                return
+            }
+            val closing =
+                try {
+                    state.socket?.close(code, reason) == true
+                } catch (_: IllegalArgumentException) {
+                    result.error("invalid_arguments", "Invalid WebSocket close code or reason.", null)
+                    return
+                }
+            if (!closing) {
+                finishWebSocket(state, code, reason, emitEvent = true)
+            }
+            result.success(null)
+        }
+
+        private fun closeAllWebSockets(emitEvents: Boolean) {
+            webSockets.entries.toList().forEach { (_, state) ->
+                state.cancelled.set(true)
+                state.socket?.cancel()
+                finishWebSocket(
+                    state,
+                    1001,
+                    "Secure transport closed.",
+                    emitEvent = emitEvents,
+                )
+            }
+        }
+
+        private inner class SecureWebSocketListener(
+            private val state: WebSocketState,
+        ) : WebSocketListener() {
+            override fun onOpen(webSocket: WebSocket, response: Response) {
+                state.socket = webSocket
+                state.opened.set(true)
+                runOnMain {
+                    if (detached || state.cancelled.get() || state.terminal.get()) {
+                        webSocket.cancel()
+                        failWebSocketStart(
+                            state,
+                            "request_cancelled",
+                            "WebSocket connection cancelled.",
+                        )
+                    } else if (state.resultCompleted.compareAndSet(false, true)) {
+                        state.result.success(null)
+                    }
+                }
+            }
+
+            override fun onMessage(webSocket: WebSocket, text: String) {
+                emitWebSocketData(state, text)
+            }
+
+            override fun onMessage(webSocket: WebSocket, bytes: ByteString) {
+                emitWebSocketData(state, bytes.utf8())
+            }
+
+            override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+                webSocket.close(code, reason)
+            }
+
+            override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+                finishWebSocket(state, code, reason, emitEvent = true)
+            }
+
+            override fun onFailure(webSocket: WebSocket, error: Throwable, response: Response?) {
+                response?.close()
+                if (state.resultCompleted.compareAndSet(false, true)) {
+                    webSockets.remove(state.socketId, state)
+                    runOnMain {
+                        if (!detached) {
+                            state.result.error(
+                                "websocket_failed",
+                                safeWebSocketFailureMessage(error),
+                                null,
+                            )
+                        }
+                    }
+                    state.cleanup()
+                } else {
+                    failWebSocket(state, safeWebSocketFailureMessage(error))
+                }
+            }
+        }
+
+        private fun emitWebSocketData(state: WebSocketState, data: String) {
+            if (!detached && state.opened.get() && !state.terminal.get()) {
+                emit(
+                    mapOf(
+                        "requestId" to state.socketId,
+                        "type" to "websocketData",
+                        "data" to data,
+                    ),
+                )
+            }
+        }
+
+        private fun failWebSocketStart(state: WebSocketState, code: String, message: String) {
+            state.terminal.set(true)
+            webSockets.remove(state.socketId, state)
+            if (state.resultCompleted.compareAndSet(false, true)) {
+                runOnMain {
+                    if (!detached) state.result.error(code, message, null)
+                }
+            }
+            state.cleanup()
+        }
+
+        private fun failWebSocket(state: WebSocketState, message: String) {
+            if (!state.terminal.compareAndSet(false, true)) return
+            webSockets.remove(state.socketId, state)
+            emit(
+                mapOf(
+                    "requestId" to state.socketId,
+                    "type" to "websocketError",
+                    "message" to message,
+                ),
+            )
+            state.cleanup()
+        }
+
+        private fun finishWebSocket(
+            state: WebSocketState,
+            code: Int,
+            reason: String,
+            emitEvent: Boolean,
+        ) {
+            if (!state.terminal.compareAndSet(false, true)) return
+            webSockets.remove(state.socketId, state)
+            if (emitEvent && !detached && state.resultCompleted.get()) {
+                emit(
+                    mapOf(
+                        "requestId" to state.socketId,
+                        "type" to "websocketClosed",
+                        "code" to code,
+                        "reason" to reason,
+                    ),
+                )
+            } else if (!state.resultCompleted.get()) {
+                completeWebSocketStartError(
+                    state,
+                    "websocket_closed",
+                    "The secure WebSocket closed before connecting.",
+                )
+            }
+            state.cleanup()
+        }
+
+        private fun completeWebSocketStartError(
+            state: WebSocketState,
+            code: String,
+            message: String,
+        ) {
+            if (state.resultCompleted.compareAndSet(false, true)) {
+                runOnMain {
+                    if (!detached) state.result.error(code, message, null)
+                }
+            }
+        }
+
+        private fun safeWebSocketFailureMessage(error: Throwable): String =
+            when (error) {
+                is SSLHandshakeException,
+                is SSLPeerUnverifiedException,
+                is SSLException -> "Secure WebSocket connection failed."
+                is SocketTimeoutException -> "Secure WebSocket connection timed out."
+                else -> "Secure WebSocket network request failed."
+            }
+
+    private inner class RequestCallback(private val state: RequestState) : Callback {
+        override fun onFailure(call: Call, error: IOException) {
+            failRequest(state, "request_failed", safeFailureMessage(error, state.cancelled.get()))
+        }
+
+        override fun onResponse(call: Call, response: Response) {
+            val body = response.body
+            state.responseBody = body
+            val metadata = mapOf(
+                "requestId" to state.requestId,
+                "statusCode" to response.code,
+                "reasonPhrase" to response.message,
+                "contentLength" to (body?.contentLength() ?: 0L),
+                "headers" to combineHeaders(response),
+            )
+            runOnMain {
+                if (detached || state.cancelled.get()) {
+                    response.close()
+                    failRequest(state, "request_cancelled", "Request cancelled.")
+                    return@runOnMain
+                }
+                if (state.resultCompleted.compareAndSet(false, true)) {
+                    state.result.success(metadata)
+                    ioExecutor.execute { streamResponse(state, response) }
+                } else {
+                    response.close()
+                    state.cleanup()
+                }
+            }
+        }
+    }
+
+    private fun combineHeaders(response: Response): Map<String, String> =
+        response.headers.names().associateWith { name ->
+            val separator = if (name.equals("set-cookie", ignoreCase = true)) "\n" else ", "
+            response.headers.values(name).joinToString(separator)
+        }
+
+    private fun streamResponse(state: RequestState, response: Response) {
+        try {
+            response.use {
+                val responseBody = it.body ?: return@use
+                responseBody.byteStream().use { input ->
+                    val buffer = ByteArray(BUFFER_SIZE)
+                    while (true) {
+                        if (state.cancelled.get()) throw InterruptedIOException()
+                        val count = input.read(buffer)
+                        if (count < 0) break
+                        if (count > 0) {
+                            emitData(state, buffer.copyOf(count))
+                        }
+                    }
+                }
+            }
+            if (state.cancelled.get()) {
+                emitError(state, "Request cancelled.")
+            } else {
+                emitDone(state)
+            }
+        } catch (error: Exception) {
+            emitError(state, safeFailureMessage(error, state.cancelled.get()))
+        } finally {
+            requests.remove(state.requestId, state)
+            state.cleanup()
+        }
+    }
+
+    private fun failRequest(state: RequestState, code: String, message: String) {
+        requests.remove(state.requestId, state)
+        state.responseBody?.closeSafely()
+        completeStartError(state, code, message)
+        emitError(state, message)
+        state.cleanup()
+    }
+
+    private fun completeStartError(state: RequestState, code: String, message: String) {
+        if (state.resultCompleted.compareAndSet(false, true)) {
+            runOnMain {
+                if (!detached) state.result.error(code, message, null)
+            }
+        }
+    }
+
+    private fun emitData(state: RequestState, data: ByteArray) {
+        synchronized(state) {
+            if (!detached && !state.cancelled.get() && !state.terminalEvent.get()) {
+                emit(mapOf("requestId" to state.requestId, "type" to "data", "data" to data))
+            }
+        }
+    }
+
+    private fun emitDone(state: RequestState) {
+        synchronized(state) {
+            if (!detached && state.terminalEvent.compareAndSet(false, true)) {
+                emit(mapOf("requestId" to state.requestId, "type" to "done"))
+            }
+        }
+    }
+
+    private fun emitError(state: RequestState, message: String) {
+        synchronized(state) {
+            if (!detached && state.terminalEvent.compareAndSet(false, true)) {
+                emit(mapOf("requestId" to state.requestId, "type" to "error", "message" to message))
+            }
+        }
+    }
+
+    private fun emit(event: Map<String, Any>) {
+        mainHandler.post {
+            if (!detached) eventSink?.success(event)
+        }
+    }
+
+    private fun safeFailureMessage(error: Exception, cancelled: Boolean): String =
+        when {
+            cancelled || error is InterruptedIOException && error !is SocketTimeoutException ->
+                "Request cancelled."
+            error is SocketTimeoutException -> "Request timed out."
+            error is SSLHandshakeException ||
+                error is SSLPeerUnverifiedException ||
+                error is SSLException -> "Secure connection failed."
+            else -> "Network request failed."
+        }
+
+    private fun runOnMain(action: () -> Unit) {
+        if (Looper.myLooper() == Looper.getMainLooper()) action() else mainHandler.post(action)
+    }
+
+    private class ChooserCallback(bridge: MtlsBridge) : KeyChainAliasCallback {
+        private val bridge = WeakReference(bridge)
+
+        override fun alias(alias: String?) {
+            bridge.get()?.onAliasChosen(alias)
+        }
+    }
+
+    private class RequestState(
+        val requestId: String,
+        val result: MethodChannel.Result,
+    ) {
+        val cancelled = AtomicBoolean(false)
+        val resultCompleted = AtomicBoolean(false)
+        val terminalEvent = AtomicBoolean(false)
+        private val cleaned = AtomicBoolean(false)
+
+        @Volatile var call: Call? = null
+        @Volatile var responseBody: ResponseBody? = null
+        @Volatile var client: OkHttpClient? = null
+
+        fun cancel() {
+            cancelled.set(true)
+            responseBody?.closeSafely()
+            call?.cancel()
+        }
+
+        fun cleanup() {
+            if (!cleaned.compareAndSet(false, true)) return
+            client?.connectionPool?.evictAll()
+            client?.dispatcher?.executorService?.shutdown()
+        }
+    }
+
+    private class WebSocketState(
+        val socketId: String,
+        val result: MethodChannel.Result,
+    ) {
+        val opened = AtomicBoolean(false)
+        val cancelled = AtomicBoolean(false)
+        val resultCompleted = AtomicBoolean(false)
+        val terminal = AtomicBoolean(false)
+        private val cleaned = AtomicBoolean(false)
+
+        @Volatile var socket: WebSocket? = null
+        @Volatile var client: OkHttpClient? = null
+
+        fun attachClient(value: OkHttpClient): Boolean =
+            synchronized(this) {
+                if (cleaned.get() || cancelled.get()) {
+                    value.connectionPool.evictAll()
+                    value.dispatcher.executorService.shutdown()
+                    false
+                } else {
+                    client = value
+                    true
+                }
+            }
+
+        fun cleanup() {
+            val activeClient =
+                synchronized(this) {
+                    if (!cleaned.compareAndSet(false, true)) return
+                    client.also { client = null }
+                }
+            activeClient?.connectionPool?.evictAll()
+            activeClient?.dispatcher?.executorService?.shutdown()
+        }
+    }
+
+    private class CertificateUnavailableException : Exception()
+
+    private fun secureClient(alias: String): OkHttpClient {
+        val keyManager = AliasKeyManager.load(context, alias)
+            ?: throw CertificateUnavailableException()
+        val trustManager = systemTrustManager()
+        val sslContext = SSLContext.getInstance("TLS").apply {
+            init(
+                arrayOf<KeyManager>(keyManager),
+                arrayOf<TrustManager>(trustManager),
+                SecureRandom(),
+            )
+        }
+        return OkHttpClient.Builder()
+            .sslSocketFactory(sslContext.socketFactory, trustManager)
+            .followRedirects(false)
+            .build()
+    }
+
+    companion object {
+        private const val METHOD_CHANNEL = "com.hermesagent.hermes_android/mtls"
+        private const val EVENT_CHANNEL = "com.hermesagent.hermes_android/mtls_events"
+        private const val BUFFER_SIZE = 32 * 1024
+        private val METHODS_REQUIRING_BODY = setOf("POST", "PUT", "PATCH", "PROPPATCH", "REPORT")
+
+        private fun systemTrustManager(): X509TrustManager {
+            val factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+            factory.init(null as KeyStore?)
+            return factory.trustManagers.filterIsInstance<X509TrustManager>().singleOrNull()
+                ?: throw IllegalStateException("No system X509 trust manager")
+        }
+    }
+}
+
+private fun ResponseBody.closeSafely() {
+    try {
+        close()
+    } catch (_: Exception) {
+        // Closing is best-effort during cancellation and teardown.
+    }
+}
+
+private class AliasKeyManager(
+    private val selectedAlias: String,
+    private val privateKey: PrivateKey,
+    private val certificateChain: Array<X509Certificate>,
+) : X509ExtendedKeyManager() {
+    private val algorithm = certificateChain.first().publicKey.algorithm
+
+    override fun getClientAliases(
+        keyType: String?,
+        issuers: Array<out Principal>?,
+    ): Array<String>? = if (eligible(keyType)) arrayOf(selectedAlias) else null
+
+    override fun chooseClientAlias(
+        keyTypes: Array<out String>?,
+        issuers: Array<out Principal>?,
+        socket: Socket?,
+    ): String? = if (keyTypes?.any(::eligible) == true) selectedAlias else null
+
+    override fun chooseEngineClientAlias(
+        keyTypes: Array<out String>?,
+        issuers: Array<out Principal>?,
+        engine: SSLEngine?,
+    ): String? = chooseClientAlias(keyTypes, issuers, null)
+
+    override fun getCertificateChain(alias: String?): Array<X509Certificate>? =
+        if (alias == selectedAlias) certificateChain.clone() else null
+
+    override fun getPrivateKey(alias: String?): PrivateKey? =
+        if (alias == selectedAlias) privateKey else null
+
+    override fun getServerAliases(
+        keyType: String?,
+        issuers: Array<out Principal>?,
+    ): Array<String>? = null
+
+    override fun chooseServerAlias(
+        keyType: String?,
+        issuers: Array<out Principal>?,
+        socket: Socket?,
+    ): String? = null
+
+    override fun chooseEngineServerAlias(
+        keyType: String?,
+        issuers: Array<out Principal>?,
+        engine: SSLEngine?,
+    ): String? = null
+
+    private fun eligible(keyType: String?): Boolean {
+        val requestedAlgorithm = keyType?.substringBefore('_')
+        return requestedAlgorithm != null &&
+            requestedAlgorithm.equals(algorithm, ignoreCase = true)
+    }
+
+    companion object {
+        fun load(context: Context, alias: String): AliasKeyManager? =
+            try {
+                val key = KeyChain.getPrivateKey(context, alias) ?: return null
+                val chain = KeyChain.getCertificateChain(context, alias) ?: return null
+                if (chain.isEmpty()) return null
+                val algorithm = chain.first().publicKey.algorithm
+                if (!algorithm.equals("RSA", ignoreCase = true) &&
+                    !algorithm.equals("EC", ignoreCase = true)
+                ) {
+                    return null
+                }
+                if (!key.algorithm.equals(algorithm, ignoreCase = true)) return null
+                AliasKeyManager(alias, key, chain)
+            } catch (_: Exception) {
+                null
+            }
+    }
+}

--- a/lib/core/models/connection.dart
+++ b/lib/core/models/connection.dart
@@ -18,9 +18,12 @@ class SavedConnection {
   final int port;
   final String apiKey;
   final bool useHttps;
+  final bool mtlsEnabled;
+  final String? mtlsCertificateAlias;
   final String? gatewayPrefix;
   final String? dashboardPrefix;
   final bool dashboardProxied;
+  final String? dashboardUrl;
 
   /// Optional Hermes Desktop remote-gateway origin. This is intentionally
   /// separate from the mobile OpenAI-compatible API and admin dashboard.
@@ -46,9 +49,12 @@ class SavedConnection {
     required this.port,
     required this.apiKey,
     this.useHttps = false,
+    this.mtlsEnabled = false,
+    this.mtlsCertificateAlias,
     this.gatewayPrefix,
     this.dashboardPrefix,
     this.dashboardProxied = false,
+    this.dashboardUrl,
     this.desktopGatewayUrl,
     this.dashboardPortOverride,
     this.dashboardUsername,
@@ -64,8 +70,22 @@ class SavedConnection {
   /// setups. Local Gateway chat connections normally use 8642 while the
   /// dashboard lives on 9119. HTTPS reverse-proxy deployments usually expose
   /// both API surfaces on the same external HTTPS port. An explicit
-  /// [dashboardPortOverride] always wins.
+  /// [dashboardPortOverride] supplies the port when [dashboardUrl] does not
+  /// contain one. A port written directly in [dashboardUrl] wins.
   int get dashboardPort => dashboardPortOverride ?? (useHttps ? port : 9119);
+
+  String get dashboardBaseUrl {
+    final configured = dashboardUrl?.trim();
+    if (configured != null && configured.isNotEmpty) {
+      final uri = Uri.parse(configured);
+      final baseUrl = dashboardPortOverride != null && !uri.hasPort
+          ? uri.replace(port: dashboardPortOverride).toString()
+          : configured;
+      return joinBaseUrl(baseUrl, dashboardPrefix ?? '');
+    }
+    final scheme = useHttps ? 'https' : 'http';
+    return joinBaseUrl('$scheme://$host:$dashboardPort', dashboardPrefix ?? '');
+  }
 
   /// Joins a base URL with an optional path prefix, normalising slashes.
   static String joinBaseUrl(String baseUrl, String pathPrefix) {
@@ -80,6 +100,18 @@ class SavedConnection {
       url = '$url$prefix';
     }
     return url;
+  }
+
+  static bool isValidDashboardUrl(String? value, {required bool requireHttps}) {
+    final raw = value?.trim() ?? '';
+    if (raw.isEmpty) return true;
+    final uri = Uri.tryParse(raw);
+    if (uri == null || uri.host.isEmpty || uri.hasQuery || uri.hasFragment) {
+      return false;
+    }
+    if (requireHttps) return uri.scheme.toLowerCase() == 'https';
+    return uri.scheme.toLowerCase() == 'http' ||
+        uri.scheme.toLowerCase() == 'https';
   }
 
   /// Parses [input] as a URI and extracts host, port, and HTTPS flag.
@@ -129,8 +161,9 @@ class SavedConnection {
 
   /// Serializes non-secret connection metadata for SharedPreferences.
   ///
-  /// [apiKey] and [dashboardPassword] intentionally never cross this boundary;
-  /// [ConnectionManager] persists them in the platform secure store instead.
+  /// [apiKey], [dashboardPassword], and [mtlsCertificateAlias] intentionally
+  /// never cross this boundary; [ConnectionManager] persists them in the
+  /// platform secure store instead.
   Map<String, dynamic> toMap() {
     final m = <String, dynamic>{
       'id': id,
@@ -138,6 +171,7 @@ class SavedConnection {
       'host': host,
       'port': port,
       'use_https': useHttps,
+      'mtls_enabled': mtlsEnabled,
       'dashboard_port': dashboardPortOverride,
     };
     if (gatewayPrefix != null && gatewayPrefix!.isNotEmpty) {
@@ -148,6 +182,9 @@ class SavedConnection {
     }
     if (dashboardProxied) {
       m['dashboard_proxied'] = dashboardProxied;
+    }
+    if (dashboardUrl != null && dashboardUrl!.isNotEmpty) {
+      m['dashboard_url'] = dashboardUrl;
     }
     if (desktopGatewayUrl != null && desktopGatewayUrl!.isNotEmpty) {
       m['desktop_gateway_url'] = desktopGatewayUrl;
@@ -173,9 +210,11 @@ class SavedConnection {
       // migrate existing installs before rewriting sanitized metadata.
       apiKey: (map['api_key'] as String?) ?? '',
       useHttps: (map['use_https'] as bool?) ?? false,
+      mtlsEnabled: (map['mtls_enabled'] as bool?) ?? false,
       gatewayPrefix: map['gateway_prefix'] as String?,
       dashboardPrefix: map['dashboard_prefix'] as String?,
       dashboardProxied: (map['dashboard_proxied'] as bool?) ?? false,
+      dashboardUrl: nonEmpty(map['dashboard_url']),
       desktopGatewayUrl: nonEmpty(map['desktop_gateway_url']),
       dashboardPortOverride: map['dashboard_port'] as int?,
       dashboardUsername: nonEmpty(map['dashboard_username']),
@@ -192,9 +231,12 @@ class SavedConnection {
     int? port,
     String? apiKey,
     bool? useHttps,
+    bool? mtlsEnabled,
+    String? mtlsCertificateAlias,
     String? gatewayPrefix,
     String? dashboardPrefix,
     bool? dashboardProxied,
+    String? dashboardUrl,
     String? desktopGatewayUrl,
     int? dashboardPortOverride,
     String? dashboardUsername,
@@ -204,7 +246,9 @@ class SavedConnection {
     bool clearDashboardPort = false,
     bool clearDashboardUsername = false,
     bool clearDashboardPassword = false,
+    bool clearDashboardUrl = false,
     bool clearDesktopGatewayUrl = false,
+    bool clearMtlsCertificateAlias = false,
   }) {
     return SavedConnection(
       id: id,
@@ -213,6 +257,10 @@ class SavedConnection {
       port: port ?? this.port,
       apiKey: apiKey ?? this.apiKey,
       useHttps: useHttps ?? this.useHttps,
+      mtlsEnabled: mtlsEnabled ?? this.mtlsEnabled,
+      mtlsCertificateAlias: clearMtlsCertificateAlias
+          ? null
+          : (mtlsCertificateAlias ?? this.mtlsCertificateAlias),
       gatewayPrefix: clearGatewayPrefix
           ? null
           : (gatewayPrefix ?? this.gatewayPrefix),
@@ -220,6 +268,9 @@ class SavedConnection {
           ? null
           : (dashboardPrefix ?? this.dashboardPrefix),
       dashboardProxied: dashboardProxied ?? this.dashboardProxied,
+      dashboardUrl: clearDashboardUrl
+          ? null
+          : (dashboardUrl ?? this.dashboardUrl),
       desktopGatewayUrl: clearDesktopGatewayUrl
           ? null
           : (desktopGatewayUrl ?? this.desktopGatewayUrl),

--- a/lib/core/screens/chat_screen.dart
+++ b/lib/core/screens/chat_screen.dart
@@ -239,12 +239,7 @@ class _ChatScreenState extends State<ChatScreen> with WidgetsBindingObserver {
     _turnNotifications = TurnNotificationService();
     unawaited(_turnNotifications.ensureInitialized());
     _client =
-        widget.testApiClient ??
-        ApiClient(
-          baseUrl: widget.connection.baseUrl,
-          apiKey: widget.connection.apiKey,
-          pathPrefix: widget.connection.gatewayPrefix ?? '',
-        );
+        widget.testApiClient ?? ApiClient.fromConnection(widget.connection);
     _gateway = GatewayChatClient(_client);
     _attachmentDraftService =
         widget.testAttachmentDraftService ?? AttachmentDraftService();

--- a/lib/core/screens/cron_screen.dart
+++ b/lib/core/screens/cron_screen.dart
@@ -26,15 +26,7 @@ class _CronScreenState extends State<CronScreen> {
   @override
   void initState() {
     super.initState();
-    _client = DashboardClient(
-      host: widget.connection.host,
-      port: widget.connection.dashboardPort,
-      pathPrefix: widget.connection.dashboardPrefix ?? "",
-      proxied: widget.connection.dashboardProxied,
-      useHttps: widget.connection.useHttps,
-      username: widget.connection.dashboardUsername,
-      password: widget.connection.dashboardPassword,
-    );
+    _client = DashboardClient.fromConnection(widget.connection);
     _loadJobs();
   }
 

--- a/lib/core/screens/memory_screen.dart
+++ b/lib/core/screens/memory_screen.dart
@@ -27,15 +27,7 @@ class _MemoryScreenState extends State<MemoryScreen> {
   @override
   void initState() {
     super.initState();
-    _client = DashboardClient(
-      host: widget.connection.host,
-      port: widget.connection.dashboardPort,
-      pathPrefix: widget.connection.dashboardPrefix ?? "",
-      proxied: widget.connection.dashboardProxied,
-      useHttps: widget.connection.useHttps,
-      username: widget.connection.dashboardUsername,
-      password: widget.connection.dashboardPassword,
-    );
+    _client = DashboardClient.fromConnection(widget.connection);
     _loadMemory();
   }
 

--- a/lib/core/screens/session_list_screen.dart
+++ b/lib/core/screens/session_list_screen.dart
@@ -72,11 +72,7 @@ class _SessionListScreenState extends State<SessionListScreen> {
   @override
   void initState() {
     super.initState();
-    _client = ApiClient(
-      baseUrl: widget.connection.baseUrl,
-      apiKey: widget.connection.apiKey,
-      pathPrefix: widget.connection.gatewayPrefix ?? '',
-    );
+    _client = ApiClient.fromConnection(widget.connection);
     if (widget.connection.desktopGatewayUrl?.trim().isNotEmpty == true) {
       try {
         _desktopGateway = DesktopGatewayClient.fromConnection(

--- a/lib/core/screens/settings_screen.dart
+++ b/lib/core/screens/settings_screen.dart
@@ -32,15 +32,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   @override
   void initState() {
     super.initState();
-    _client = DashboardClient(
-      host: widget.connection.host,
-      port: widget.connection.dashboardPort,
-      pathPrefix: widget.connection.dashboardPrefix ?? "",
-      proxied: widget.connection.dashboardProxied,
-      useHttps: widget.connection.useHttps,
-      username: widget.connection.dashboardUsername,
-      password: widget.connection.dashboardPassword,
-    );
+    _client = DashboardClient.fromConnection(widget.connection);
     _loadData();
   }
 

--- a/lib/core/screens/skills_screen.dart
+++ b/lib/core/screens/skills_screen.dart
@@ -19,15 +19,7 @@ class _SkillsScreenState extends State<SkillsScreen> {
   @override
   void initState() {
     super.initState();
-    _client = DashboardClient(
-      host: widget.connection.host,
-      port: widget.connection.dashboardPort,
-      pathPrefix: widget.connection.dashboardPrefix ?? "",
-      proxied: widget.connection.dashboardProxied,
-      useHttps: widget.connection.useHttps,
-      username: widget.connection.dashboardUsername,
-      password: widget.connection.dashboardPassword,
-    );
+    _client = DashboardClient.fromConnection(widget.connection);
     _load();
   }
 

--- a/lib/core/services/connection_manager.dart
+++ b/lib/core/services/connection_manager.dart
@@ -2,12 +2,15 @@
 
 import 'dart:async';
 import 'dart:convert';
+
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
+
 import '../models/connection.dart';
 import '../models/session.dart';
+import 'mtls_client.dart';
 
 // Re-export for convenience
 export '../models/connection.dart';
@@ -78,17 +81,23 @@ class CredentialStorageException implements Exception {
 class _ConnectionCredentials {
   final String apiKey;
   final String? dashboardPassword;
+  final String? mtlsCertificateAlias;
 
   const _ConnectionCredentials({
     required this.apiKey,
     required this.dashboardPassword,
+    required this.mtlsCertificateAlias,
   });
 
-  bool get isEmpty => apiKey.isEmpty && dashboardPassword == null;
+  bool get isEmpty =>
+      apiKey.isEmpty &&
+      dashboardPassword == null &&
+      mtlsCertificateAlias == null;
 
   String encode() => jsonEncode(<String, String>{
     if (apiKey.isNotEmpty) 'api_key': apiKey,
     'dashboard_password': ?dashboardPassword,
+    'mtls_certificate_alias': ?mtlsCertificateAlias,
   });
 
   static _ConnectionCredentials decode(String encoded) {
@@ -96,16 +105,20 @@ class _ConnectionCredentials {
       final map = jsonDecode(encoded) as Map<String, dynamic>;
       final apiKey = map['api_key'];
       final dashboardPassword = map['dashboard_password'];
+      final mtlsCertificateAlias = map['mtls_certificate_alias'];
       if (apiKey != null && apiKey is! String ||
-          dashboardPassword != null && dashboardPassword is! String) {
+          dashboardPassword != null && dashboardPassword is! String ||
+          mtlsCertificateAlias != null && mtlsCertificateAlias is! String) {
         throw const FormatException();
       }
       final password = (dashboardPassword as String?)?.trim();
+      final alias = (mtlsCertificateAlias as String?)?.trim();
       return _ConnectionCredentials(
         apiKey: (apiKey as String?) ?? '',
         dashboardPassword: password == null || password.isEmpty
             ? null
             : password,
+        mtlsCertificateAlias: alias == null || alias.isEmpty ? null : alias,
       );
     } catch (_) {
       throw const CredentialStorageException(
@@ -119,6 +132,7 @@ class _ConnectionCredentials {
     return _ConnectionCredentials(
       apiKey: connection.apiKey,
       dashboardPassword: password == null || password.isEmpty ? null : password,
+      mtlsCertificateAlias: connection.mtlsCertificateAlias,
     );
   }
 }
@@ -128,6 +142,8 @@ class _ConnectionCredentials {
 class ConnectionManager {
   static const String _key = 'saved_connections';
   static const String _credentialKeyPrefix = 'connection_credentials_v1.';
+  static const String _legacyDesktopGatewayDefault =
+      'http://192.168.1.193/desktop';
   static const Uuid _uuid = Uuid();
   static final CredentialStore _sharedCredentialStore =
       FlutterSecureCredentialStore();
@@ -154,7 +170,19 @@ class ConnectionManager {
   /// partial secure-store failure leaves every legacy profile retryable.
   Future<void> initialize() async {
     final maps = _readConnectionMaps();
-    final connections = _connectionsFromMaps(maps);
+    final storedConnections = _connectionsFromMaps(maps);
+    final hasLegacyDesktopGatewayDefault = storedConnections.any(
+      (connection) =>
+          connection.desktopGatewayUrl == _legacyDesktopGatewayDefault,
+    );
+    final connections = storedConnections
+        .map(
+          (connection) =>
+              connection.desktopGatewayUrl == _legacyDesktopGatewayDefault
+              ? connection.copyWith(clearDesktopGatewayUrl: true)
+              : connection,
+        )
+        .toList();
     final hasLegacyFields = maps.any(
       (map) =>
           map.containsKey('api_key') || map.containsKey('dashboard_password'),
@@ -177,7 +205,7 @@ class ConnectionManager {
         }
       }
 
-      if (hasLegacyFields) {
+      if (hasLegacyFields || hasLegacyDesktopGatewayDefault) {
         await _saveAll(connections);
       }
     } on CredentialStorageException {
@@ -203,12 +231,28 @@ class ConnectionManager {
     String? gatewayPrefix,
     String? dashboardPrefix,
     bool dashboardProxied = false,
+    String? dashboardUrl,
     String? desktopGatewayUrl,
     int? dashboardPort,
     String? dashboardUsername,
     String? dashboardPassword,
+    bool mtlsEnabled = false,
+    String? mtlsCertificateAlias,
   }) async {
+    final alias = mtlsCertificateAlias?.trim();
+    if (mtlsEnabled && (alias == null || alias.isEmpty)) {
+      throw ArgumentError('An mTLS certificate must be selected');
+    }
     final normalized = SavedConnection.normalizeHostAndPort(host, port);
+    if (mtlsEnabled && !normalized.useHttps) {
+      throw ArgumentError('mTLS connections require HTTPS');
+    }
+    if (!SavedConnection.isValidDashboardUrl(
+      dashboardUrl,
+      requireHttps: mtlsEnabled,
+    )) {
+      throw ArgumentError('Invalid dashboard URL');
+    }
     final conn = SavedConnection(
       id: _uuid.v4(),
       label: label,
@@ -216,9 +260,12 @@ class ConnectionManager {
       port: normalized.port,
       apiKey: apiKey,
       useHttps: normalized.useHttps,
+      mtlsEnabled: mtlsEnabled,
+      mtlsCertificateAlias: mtlsEnabled ? alias : null,
       gatewayPrefix: gatewayPrefix,
       dashboardPrefix: dashboardPrefix,
       dashboardProxied: dashboardProxied,
+      dashboardUrl: dashboardUrl?.trim(),
       desktopGatewayUrl: desktopGatewayUrl?.trim(),
       dashboardPortOverride: dashboardPort,
       dashboardUsername: dashboardUsername,
@@ -231,6 +278,7 @@ class ConnectionManager {
       previousCredentials: const _ConnectionCredentials(
         apiKey: '',
         dashboardPassword: null,
+        mtlsCertificateAlias: null,
       ),
       nextCredentials: _ConnectionCredentials.fromConnection(conn),
       connections: current,
@@ -248,10 +296,13 @@ class ConnectionManager {
     String? gatewayPrefix,
     String? dashboardPrefix,
     bool dashboardProxied = false,
+    String? dashboardUrl,
     String? desktopGatewayUrl,
     int? dashboardPort,
     String? dashboardUsername,
     String? dashboardPassword,
+    bool? mtlsEnabled,
+    String? mtlsCertificateAlias,
   }) async {
     final current = getConnections();
     final idx = current.indexWhere((c) => c.id == connId);
@@ -264,9 +315,26 @@ class ConnectionManager {
     final normalized = SavedConnection.normalizeHostAndPort(host, port);
     final gateway = gatewayPrefix?.trim();
     final dashboard = dashboardPrefix?.trim();
+    final dashboardEndpoint = dashboardUrl?.trim();
     final dashUser = dashboardUsername?.trim();
     final dashPass = dashboardPassword?.trim();
     final desktopGateway = desktopGatewayUrl?.trim();
+    final useMtls = mtlsEnabled ?? current[idx].mtlsEnabled;
+    final mtlsAlias =
+        mtlsCertificateAlias?.trim() ??
+        current[idx].mtlsCertificateAlias?.trim();
+    if (useMtls && (mtlsAlias == null || mtlsAlias.isEmpty)) {
+      throw ArgumentError('An mTLS certificate must be selected');
+    }
+    if (useMtls && !normalized.useHttps) {
+      throw ArgumentError('mTLS connections require HTTPS');
+    }
+    if (!SavedConnection.isValidDashboardUrl(
+      dashboardEndpoint,
+      requireHttps: useMtls,
+    )) {
+      throw ArgumentError('Invalid dashboard URL');
+    }
 
     current[idx] = current[idx].copyWith(
       label: label,
@@ -274,6 +342,9 @@ class ConnectionManager {
       port: normalized.port,
       apiKey: apiKey,
       useHttps: normalized.useHttps,
+      mtlsEnabled: useMtls,
+      mtlsCertificateAlias: useMtls ? mtlsAlias : null,
+      clearMtlsCertificateAlias: !useMtls,
       gatewayPrefix: gateway == null || gateway.isEmpty ? null : gateway,
       clearGatewayPrefix: gateway != null && gateway.isEmpty,
       dashboardPrefix: dashboard == null || dashboard.isEmpty
@@ -281,6 +352,10 @@ class ConnectionManager {
           : dashboard,
       clearDashboardPrefix: dashboard != null && dashboard.isEmpty,
       dashboardProxied: dashboardProxied,
+      dashboardUrl: dashboardEndpoint == null || dashboardEndpoint.isEmpty
+          ? null
+          : dashboardEndpoint,
+      clearDashboardUrl: dashboardEndpoint != null && dashboardEndpoint.isEmpty,
       desktopGatewayUrl: desktopGateway == null || desktopGateway.isEmpty
           ? null
           : desktopGateway,
@@ -309,6 +384,7 @@ class ConnectionManager {
     required String password,
     String? gatewayPrefix,
     String? dashboardPrefix,
+    String? dashboardUrl,
     bool? dashboardProxied,
   }) async {
     final current = getConnections();
@@ -321,6 +397,13 @@ class ConnectionManager {
     final p = password.trim();
     final gateway = gatewayPrefix?.trim();
     final dashboard = dashboardPrefix?.trim();
+    final dashboardEndpoint = dashboardUrl?.trim();
+    if (!SavedConnection.isValidDashboardUrl(
+      dashboardEndpoint,
+      requireHttps: current[idx].mtlsEnabled,
+    )) {
+      throw ArgumentError('Invalid dashboard URL');
+    }
     current[idx] = current[idx].copyWith(
       gatewayPrefix: gateway == null || gateway.isEmpty ? null : gateway,
       clearGatewayPrefix: gateway != null && gateway.isEmpty,
@@ -329,6 +412,10 @@ class ConnectionManager {
           : dashboard,
       clearDashboardPrefix: dashboard != null && dashboard.isEmpty,
       dashboardProxied: dashboardProxied,
+      dashboardUrl: dashboardEndpoint == null || dashboardEndpoint.isEmpty
+          ? null
+          : dashboardEndpoint,
+      clearDashboardUrl: dashboardEndpoint != null && dashboardEndpoint.isEmpty,
       dashboardPortOverride: dashboardPort,
       clearDashboardPort: dashboardPort == null,
       dashboardUsername: u.isEmpty ? null : u,
@@ -374,6 +461,7 @@ class ConnectionManager {
       nextCredentials: const _ConnectionCredentials(
         apiKey: '',
         dashboardPassword: null,
+        mtlsCertificateAlias: null,
       ),
       connections: current,
     );
@@ -410,6 +498,8 @@ class ConnectionManager {
       apiKey: credentials.apiKey,
       dashboardPassword: credentials.dashboardPassword,
       clearDashboardPassword: credentials.dashboardPassword == null,
+      mtlsCertificateAlias: credentials.mtlsCertificateAlias,
+      clearMtlsCertificateAlias: credentials.mtlsCertificateAlias == null,
     );
   }
 
@@ -506,6 +596,29 @@ class ApiClient {
   }) : _apiKey = apiKey,
        baseUrl = SavedConnection.joinBaseUrl(baseUrl, pathPrefix),
        _http = httpClient ?? http.Client();
+
+  factory ApiClient.fromConnection(
+    SavedConnection connection, {
+    http.Client? httpClient,
+    MtlsTransport? mtlsTransport,
+  }) {
+    if (connection.apiKey.trim().isNotEmpty && !connection.useHttps) {
+      throw ArgumentError(
+        'Gateway API keys require HTTPS to prevent credential exposure',
+      );
+    }
+    return ApiClient(
+      baseUrl: connection.baseUrl,
+      apiKey: connection.apiKey,
+      pathPrefix: connection.gatewayPrefix ?? '',
+      httpClient:
+          httpClient ??
+          GatewayHttpClientFactory.create(
+            connection,
+            mtlsTransport: mtlsTransport,
+          ),
+    );
+  }
 
   Map<String, String> get _headers => {
     'Authorization': 'Bearer $_apiKey',
@@ -642,6 +755,13 @@ class ApiClient {
     if (res.statusCode < 200 || res.statusCode >= 300) {
       throw Exception('HTTP ${res.statusCode}');
     }
+  }
+
+  Future<bool> cancelPendingRequests() {
+    final client = _http;
+    return client is MtlsHttpClient
+        ? client.cancelPendingRequests()
+        : Future<bool>.value(false);
   }
 
   // ── Dashboard-compatible helpers (port 9119 endpoints, may not work on API server) ──
@@ -888,6 +1008,8 @@ class GatewayChatClient {
     final subscription = _activeStreamSubscription;
     if (subscription != null) {
       await subscription.cancel();
+    } else {
+      await _api.cancelPendingRequests();
     }
     if (!completion.isCompleted) completion.complete();
     return true;
@@ -915,6 +1037,19 @@ class GatewayChatClient {
 ///    on a dashboard started with `--insecure`.
 ///
 /// Used for Dashboard-only features: cron, memory, skills, settings.
+class DashboardWebSocketCredential {
+  final String? token;
+  final String? ticket;
+
+  const DashboardWebSocketCredential.token(String value)
+    : token = value,
+      ticket = null;
+
+  const DashboardWebSocketCredential.ticket(String value)
+    : token = null,
+      ticket = value;
+}
+
 class DashboardClient {
   final http.Client _http;
   final String _baseUrl;
@@ -934,7 +1069,7 @@ class DashboardClient {
   bool get _usesPasswordAuth =>
       (_username?.isNotEmpty ?? false) && (_password?.isNotEmpty ?? false);
 
-  DashboardClient({
+  factory DashboardClient({
     required String host,
     int port = 9119,
     bool useHttps = false,
@@ -943,14 +1078,59 @@ class DashboardClient {
     String? username,
     String? password,
     http.Client? httpClient,
+  }) {
+    return DashboardClient._(
+      baseUrl: SavedConnection.joinBaseUrl(
+        '${useHttps ? 'https' : 'http'}://$host:$port',
+        pathPrefix,
+      ),
+      proxied: proxied,
+      username: username,
+      password: password,
+      httpClient: httpClient ?? http.Client(),
+    );
+  }
+
+  factory DashboardClient.fromConnection(
+    SavedConnection connection, {
+    http.Client? httpClient,
+    MtlsTransport? mtlsTransport,
+  }) {
+    final hasPasswordAuth =
+        (connection.dashboardUsername?.trim().isNotEmpty ?? false) &&
+        (connection.dashboardPassword?.trim().isNotEmpty ?? false);
+    if (hasPasswordAuth &&
+        Uri.parse(connection.dashboardBaseUrl).scheme.toLowerCase() !=
+            'https') {
+      throw ArgumentError(
+        'Dashboard credentials require HTTPS to prevent credential exposure',
+      );
+    }
+    return DashboardClient._(
+      baseUrl: connection.dashboardBaseUrl,
+      proxied: connection.dashboardProxied,
+      username: connection.dashboardUsername,
+      password: connection.dashboardPassword,
+      httpClient:
+          httpClient ??
+          GatewayHttpClientFactory.create(
+            connection,
+            mtlsTransport: mtlsTransport,
+          ),
+    );
+  }
+
+  DashboardClient._({
+    required String baseUrl,
+    required bool proxied,
+    required String? username,
+    required String? password,
+    required http.Client httpClient,
   }) : _proxied = proxied,
        _username = username,
        _password = password,
-       _baseUrl = SavedConnection.joinBaseUrl(
-         '${useHttps ? 'https' : 'http'}://$host:$port',
-         pathPrefix,
-       ),
-       _http = httpClient ?? http.Client();
+       _baseUrl = baseUrl,
+       _http = httpClient;
 
   /// Clears any cached auth state so the next request re-authenticates.
   void _resetAuth() {
@@ -1063,6 +1243,13 @@ class DashboardClient {
       throw Exception('Desktop gateway returned no WebSocket ticket');
     }
     return ticket;
+  }
+
+  Future<DashboardWebSocketCredential> getWebSocketCredential() async {
+    if (!_proxied && !_usesPasswordAuth) {
+      return DashboardWebSocketCredential.token(await _getToken());
+    }
+    return DashboardWebSocketCredential.ticket(await mintWebSocketTicket());
   }
 
   Map<String, dynamic> _decodeMapResponse(http.Response res) {

--- a/lib/core/services/desktop_gateway_client.dart
+++ b/lib/core/services/desktop_gateway_client.dart
@@ -6,6 +6,8 @@ import 'package:crypto/crypto.dart';
 import 'connection_manager.dart';
 import 'gateway_turn_coordinator.dart';
 import 'gateway_turn_journal.dart';
+import 'mtls_client.dart';
+import 'websocket_transport.dart';
 import 'ws_client.dart';
 
 typedef DesktopAsyncEventCallback =
@@ -30,11 +32,17 @@ class DesktopGatewayClient {
   final String _baseUrl;
   final DashboardClient _dashboard;
   final String _documentProfile;
+  final GatewayWebSocketChannelFactory _channelFactory;
   WsClient? _ws;
+  WsClient? _connectingWs;
+  Future<WsClient>? _socketConnection;
   final Map<String, String> _gatewaySessionIds = {};
+  final Map<String, Future<_DesktopGatewaySession>> _sessionConnections = {};
   DesktopAsyncEventCallback? _asyncEventListener;
   DesktopConnectionCallback? _connectionListener;
   GatewayTurnCoordinatorRegistry? _turnCoordinatorRegistry;
+  int _lifecycleGeneration = 0;
+  bool _closed = false;
 
   static const _asyncEventTypes = {
     'background.complete',
@@ -54,9 +62,14 @@ class DesktopGatewayClient {
     required this._baseUrl,
     required this._dashboard,
     required this._documentProfile,
+    required this._channelFactory,
   });
 
-  factory DesktopGatewayClient.fromConnection(SavedConnection connection) {
+  factory DesktopGatewayClient.fromConnection(
+    SavedConnection connection, {
+    MtlsTransport? mtlsTransport,
+    MtlsWebSocketTransport? mtlsWebSocketTransport,
+  }) {
     final raw = connection.desktopGatewayUrl?.trim() ?? '';
     if (raw.isEmpty) {
       throw ArgumentError('A Desktop Gateway URL is required for this feature');
@@ -67,6 +80,9 @@ class DesktopGatewayClient {
         uri.host.isEmpty ||
         (uri.scheme != 'http' && uri.scheme != 'https')) {
       throw ArgumentError('Desktop Gateway URL must be an http(s) URL');
+    }
+    if (uri.scheme != 'https') {
+      throw ArgumentError('Desktop Gateway credentials require HTTPS');
     }
     final baseUri = uri.replace(query: '', fragment: '');
     final pathPrefix = baseUri.path == '/' ? '' : baseUri.path;
@@ -79,6 +95,19 @@ class DesktopGatewayClient {
       '${baseUri.scheme}://${baseUri.host}:$port',
       pathPrefix,
     );
+    final alias = connection.mtlsCertificateAlias?.trim();
+    if (connection.mtlsEnabled && (alias == null || alias.isEmpty)) {
+      throw ArgumentError(
+        'An mTLS certificate is required for the Desktop Gateway',
+      );
+    }
+    final channelFactory = connection.mtlsEnabled
+        ? (Uri socketUri) => MtlsWebSocketChannel.connect(
+            socketUri,
+            alias: alias!,
+            transport: mtlsWebSocketTransport,
+          )
+        : IoGatewayWebSocketChannel.connect;
     return DesktopGatewayClient._(
       connectionId: connection.id,
       baseUrl: baseUrl,
@@ -87,34 +116,107 @@ class DesktopGatewayClient {
         port: port,
         useHttps: baseUri.scheme == 'https',
         pathPrefix: pathPrefix,
+        proxied: connection.dashboardProxied,
         username: connection.dashboardUsername,
         password: connection.dashboardPassword,
+        httpClient: GatewayHttpClientFactory.create(
+          connection,
+          mtlsTransport: mtlsTransport,
+        ),
       ),
       documentProfile: documentIntakeProfileForConnection(connection),
+      channelFactory: channelFactory,
     );
   }
 
-  Future<_DesktopGatewaySession> _connect(String mobileSessionId) async {
+  WsClient _createSocketClient(DashboardWebSocketCredential credential) =>
+      WsClient(
+        _baseUrl,
+        token: credential.token,
+        ticket: credential.ticket,
+        channelFactory: _channelFactory,
+      );
+
+  Future<_DesktopGatewaySession> _connect(String mobileSessionId) {
+    if (_closed) {
+      return Future.error(StateError('The Desktop Gateway client is closed'));
+    }
     final existing = _ws;
     if (existing != null && existing.isConnected) {
       final mappedSessionId = _gatewaySessionIds[mobileSessionId];
       if (mappedSessionId != null) {
-        return _DesktopGatewaySession(existing, mappedSessionId);
+        return Future.value(_DesktopGatewaySession(existing, mappedSessionId));
       }
-      final gatewaySessionId = await _resumeOrCreate(existing, mobileSessionId);
-      _gatewaySessionIds[mobileSessionId] = gatewaySessionId;
-      return _DesktopGatewaySession(existing, gatewaySessionId);
     }
 
+    final pending = _sessionConnections[mobileSessionId];
+    if (pending != null) return pending;
+    final future = _connectSession(mobileSessionId);
+    _sessionConnections[mobileSessionId] = future;
+    future.then<void>(
+      (_) {
+        if (identical(_sessionConnections[mobileSessionId], future)) {
+          _sessionConnections.remove(mobileSessionId);
+        }
+      },
+      onError: (_, _) {
+        if (identical(_sessionConnections[mobileSessionId], future)) {
+          _sessionConnections.remove(mobileSessionId);
+        }
+      },
+    );
+    return future;
+  }
+
+  Future<_DesktopGatewaySession> _connectSession(String mobileSessionId) async {
+    final client = await _connectedSocket();
+    _requireOpen();
+    final mappedSessionId = _gatewaySessionIds[mobileSessionId];
+    if (mappedSessionId != null) {
+      return _DesktopGatewaySession(client, mappedSessionId);
+    }
+    final gatewaySessionId = await _resumeOrCreate(client, mobileSessionId);
+    _requireOpen();
+    if (!identical(_ws, client) || !client.isConnected) {
+      throw StateError('The Desktop Gateway connection changed');
+    }
+    _gatewaySessionIds[mobileSessionId] = gatewaySessionId;
+    return _DesktopGatewaySession(client, gatewaySessionId);
+  }
+
+  Future<WsClient> _connectedSocket() {
+    _requireOpen();
+    final existing = _ws;
+    if (existing != null && existing.isConnected) return Future.value(existing);
+    final pending = _socketConnection;
+    if (pending != null) return pending;
+    final generation = _lifecycleGeneration;
+    final future = _openSocket(generation, existing);
+    _socketConnection = future;
+    future.then<void>(
+      (_) {
+        if (identical(_socketConnection, future)) _socketConnection = null;
+      },
+      onError: (_, _) {
+        if (identical(_socketConnection, future)) _socketConnection = null;
+      },
+    );
+    return future;
+  }
+
+  Future<WsClient> _openSocket(int generation, WsClient? previous) async {
     _connectionListener?.call(
-      existing == null
+      previous == null
           ? DesktopConnectionState.connecting
           : DesktopConnectionState.reconnecting,
     );
-    existing?.close();
+    _ws = null;
+    previous?.close();
     _gatewaySessionIds.clear();
-    final ticket = await _dashboard.mintWebSocketTicket();
-    final client = WsClient(_baseUrl, ticket: ticket);
+    final credential = await _dashboard.getWebSocketCredential();
+    _requireGeneration(generation);
+    final client = _createSocketClient(credential);
+    _connectingWs = client;
     _installAsyncEventBridge(client);
     client.onConnectionChanged = (connected) {
       if (connected) {
@@ -126,15 +228,32 @@ class DesktopGatewayClient {
     };
     try {
       await client.connect();
+      _requireGeneration(generation);
+      if (!identical(_connectingWs, client)) {
+        throw StateError('The Desktop Gateway connection was superseded');
+      }
+      _connectingWs = null;
       _ws = client;
-      final gatewaySessionId = await _resumeOrCreate(client, mobileSessionId);
-      _gatewaySessionIds[mobileSessionId] = gatewaySessionId;
-      return _DesktopGatewaySession(client, gatewaySessionId);
+      return client;
     } catch (_) {
       client.close();
+      if (identical(_connectingWs, client)) _connectingWs = null;
       if (identical(_ws, client)) _ws = null;
-      _connectionListener?.call(DesktopConnectionState.disconnected);
+      if (!_closed && generation == _lifecycleGeneration) {
+        _connectionListener?.call(DesktopConnectionState.disconnected);
+      }
       rethrow;
+    }
+  }
+
+  void _requireOpen() {
+    if (_closed) throw StateError('The Desktop Gateway client is closed');
+  }
+
+  void _requireGeneration(int generation) {
+    _requireOpen();
+    if (generation != _lifecycleGeneration) {
+      throw StateError('The Desktop Gateway connection was superseded');
     }
   }
 
@@ -170,8 +289,11 @@ class DesktopGatewayClient {
       endpointDigest: sha256.convert(utf8.encode(_baseUrl)).toString(),
       journal: journal ?? GatewayTurnJournal(),
       freshSocketFactory: () async {
-        final ticket = await _dashboard.mintWebSocketTicket();
-        return WsClient(_baseUrl, ticket: ticket);
+        _requireOpen();
+        final generation = _lifecycleGeneration;
+        final credential = await _dashboard.getWebSocketCredential();
+        _requireGeneration(generation);
+        return _createSocketClient(credential);
       },
     );
   }
@@ -346,11 +468,18 @@ class DesktopGatewayClient {
   }
 
   void close() {
+    if (_closed) return;
+    _closed = true;
+    _lifecycleGeneration++;
     _asyncEventListener = null;
     _connectionListener = null;
+    _connectingWs?.close();
+    _connectingWs = null;
     _ws?.close();
     _ws = null;
+    _socketConnection = null;
     _gatewaySessionIds.clear();
+    _sessionConnections.clear();
     final turnCoordinatorRegistry = _turnCoordinatorRegistry;
     _turnCoordinatorRegistry = null;
     if (turnCoordinatorRegistry != null) {

--- a/lib/core/services/gateway_turn_application_controller.dart
+++ b/lib/core/services/gateway_turn_application_controller.dart
@@ -204,7 +204,9 @@ String _connectionScopeKey(SavedConnection connection) {
   final credentialDigest = sha256
       .convert(
         utf8.encode(
-          '${connection.apiKey}\u0000${connection.dashboardPassword ?? ''}',
+          '${connection.apiKey}\u0000'
+          '${connection.dashboardPassword ?? ''}\u0000'
+          '${connection.mtlsCertificateAlias ?? ''}',
         ),
       )
       .toString();
@@ -218,6 +220,7 @@ String _connectionScopeKey(SavedConnection connection) {
             'dashboard_prefix': connection.dashboardPrefix,
             'dashboard_port': connection.dashboardPort,
             'dashboard_proxied': connection.dashboardProxied,
+            'mtls_enabled': connection.mtlsEnabled,
             'credential_digest': credentialDigest,
           }),
         ),

--- a/lib/core/services/mtls_client.dart
+++ b/lib/core/services/mtls_client.dart
@@ -1,0 +1,682 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:http/http.dart' as http;
+import 'package:uuid/uuid.dart';
+
+import '../models/connection.dart';
+import 'websocket_transport.dart';
+
+class MtlsCertificate {
+  final String alias;
+  final String label;
+
+  const MtlsCertificate({required this.alias, required this.label});
+
+  factory MtlsCertificate.fromMap(Map<Object?, Object?> map) {
+    final alias = map['alias'];
+    final label = map['label'];
+    if (alias is! String ||
+        alias.isEmpty ||
+        label is! String ||
+        label.isEmpty) {
+      throw const FormatException('Invalid mTLS certificate response');
+    }
+    return MtlsCertificate(alias: alias, label: label);
+  }
+}
+
+class MtlsRequest {
+  final String requestId;
+  final String alias;
+  final String method;
+  final Uri url;
+  final Map<String, String> headers;
+  final Uint8List? body;
+
+  const MtlsRequest({
+    required this.requestId,
+    required this.alias,
+    required this.method,
+    required this.url,
+    required this.headers,
+    required this.body,
+  });
+}
+
+class MtlsResponseHead {
+  final int statusCode;
+  final String? reasonPhrase;
+  final int? contentLength;
+  final Map<String, String> headers;
+
+  const MtlsResponseHead({
+    required this.statusCode,
+    required this.reasonPhrase,
+    required this.contentLength,
+    required this.headers,
+  });
+
+  factory MtlsResponseHead.fromMap(Map<Object?, Object?> map) {
+    final statusCode = map['statusCode'];
+    if (statusCode is! int) {
+      throw const FormatException('Invalid mTLS response status');
+    }
+    final rawHeaders = map['headers'];
+    final headers = <String, String>{};
+    if (rawHeaders is Map) {
+      for (final entry in rawHeaders.entries) {
+        if (entry.key is String && entry.value is String) {
+          headers[entry.key as String] = entry.value as String;
+        }
+      }
+    }
+    final length = map['contentLength'];
+    return MtlsResponseHead(
+      statusCode: statusCode,
+      reasonPhrase: map['reasonPhrase'] as String?,
+      contentLength: length is int && length >= 0 ? length : null,
+      headers: headers,
+    );
+  }
+}
+
+sealed class MtlsResponseEvent {
+  final String requestId;
+
+  const MtlsResponseEvent(this.requestId);
+}
+
+class MtlsDataEvent extends MtlsResponseEvent {
+  final Uint8List data;
+
+  const MtlsDataEvent(super.requestId, this.data);
+}
+
+class MtlsDoneEvent extends MtlsResponseEvent {
+  const MtlsDoneEvent(super.requestId);
+}
+
+class MtlsErrorEvent extends MtlsResponseEvent {
+  final String message;
+
+  const MtlsErrorEvent(super.requestId, this.message);
+}
+
+class MtlsWebSocketDataEvent extends MtlsResponseEvent {
+  final String data;
+
+  const MtlsWebSocketDataEvent(super.requestId, this.data);
+}
+
+class MtlsWebSocketClosedEvent extends MtlsResponseEvent {
+  final int code;
+  final String reason;
+
+  const MtlsWebSocketClosedEvent(
+    super.requestId, {
+    required this.code,
+    required this.reason,
+  });
+}
+
+class MtlsWebSocketErrorEvent extends MtlsResponseEvent {
+  final String message;
+
+  const MtlsWebSocketErrorEvent(super.requestId, this.message);
+}
+
+abstract interface class MtlsTransport {
+  Stream<MtlsResponseEvent> get events;
+
+  Future<MtlsCertificate?> chooseCertificate({
+    String? host,
+    int? port,
+    String? alias,
+  });
+
+  Future<MtlsCertificate?> describeCertificate(String alias);
+
+  Future<MtlsResponseHead> startRequest(MtlsRequest request);
+
+  Future<bool> cancelRequest(String requestId);
+}
+
+abstract interface class MtlsWebSocketTransport {
+  Stream<MtlsResponseEvent> get events;
+
+  Future<void> startWebSocket({
+    required String socketId,
+    required String alias,
+    required Uri url,
+  });
+
+  Future<void> sendWebSocket({required String socketId, required String data});
+
+  Future<void> closeWebSocket({
+    required String socketId,
+    int code = 1000,
+    String reason = '',
+  });
+}
+
+class MethodChannelMtlsTransport
+    implements MtlsTransport, MtlsWebSocketTransport {
+  static const _methodChannel = MethodChannel(
+    'com.hermesagent.hermes_android/mtls',
+  );
+  static const _eventChannel = EventChannel(
+    'com.hermesagent.hermes_android/mtls_events',
+  );
+  static final MethodChannelMtlsTransport instance =
+      MethodChannelMtlsTransport._();
+
+  late final Stream<MtlsResponseEvent> _events = _eventChannel
+      .receiveBroadcastStream()
+      .map(_decodeEvent);
+
+  MethodChannelMtlsTransport._();
+
+  @override
+  Stream<MtlsResponseEvent> get events => _events;
+
+  @override
+  Future<MtlsCertificate?> chooseCertificate({
+    String? host,
+    int? port,
+    String? alias,
+  }) async {
+    _requireAndroid();
+    final result = await _methodChannel.invokeMapMethod<Object?, Object?>(
+      'chooseCertificate',
+      <String, Object?>{'host': host, 'port': port, 'alias': alias},
+    );
+    return result == null ? null : MtlsCertificate.fromMap(result);
+  }
+
+  @override
+  Future<MtlsCertificate?> describeCertificate(String alias) async {
+    _requireAndroid();
+    final result = await _methodChannel.invokeMapMethod<Object?, Object?>(
+      'describeCertificate',
+      <String, Object?>{'alias': alias},
+    );
+    return result == null ? null : MtlsCertificate.fromMap(result);
+  }
+
+  @override
+  Future<MtlsResponseHead> startRequest(MtlsRequest request) async {
+    _requireAndroid();
+    await _methodChannel.invokeMethod<void>('waitUntilEventStreamReady');
+    final result = await _methodChannel
+        .invokeMapMethod<Object?, Object?>('startRequest', <String, Object?>{
+          'requestId': request.requestId,
+          'alias': request.alias,
+          'method': request.method,
+          'url': request.url.toString(),
+          'headers': request.headers,
+          'body': request.body,
+        });
+    if (result == null) {
+      throw PlatformException(
+        code: 'invalid_response',
+        message: 'The native mTLS client returned no response.',
+      );
+    }
+    return MtlsResponseHead.fromMap(result);
+  }
+
+  @override
+  Future<bool> cancelRequest(String requestId) async {
+    _requireAndroid();
+    return await _methodChannel.invokeMethod<bool>(
+          'cancelRequest',
+          <String, Object?>{'requestId': requestId},
+        ) ??
+        false;
+  }
+
+  @override
+  Future<void> startWebSocket({
+    required String socketId,
+    required String alias,
+    required Uri url,
+  }) async {
+    _requireAndroid();
+    await _methodChannel.invokeMethod<void>('waitUntilEventStreamReady');
+    await _methodChannel.invokeMethod<void>('startWebSocket', <String, Object?>{
+      'socketId': socketId,
+      'alias': alias,
+      'url': url.toString(),
+    });
+  }
+
+  @override
+  Future<void> sendWebSocket({
+    required String socketId,
+    required String data,
+  }) async {
+    _requireAndroid();
+    final sent = await _methodChannel.invokeMethod<bool>(
+      'sendWebSocket',
+      <String, Object?>{'socketId': socketId, 'data': data},
+    );
+    if (sent != true) {
+      throw PlatformException(
+        code: 'websocket_send_failed',
+        message: 'The secure WebSocket message could not be sent.',
+      );
+    }
+  }
+
+  @override
+  Future<void> closeWebSocket({
+    required String socketId,
+    int code = 1000,
+    String reason = '',
+  }) async {
+    _requireAndroid();
+    await _methodChannel.invokeMethod<void>('closeWebSocket', <String, Object?>{
+      'socketId': socketId,
+      'code': code,
+      'reason': reason,
+    });
+  }
+
+  static MtlsResponseEvent _decodeEvent(dynamic value) {
+    if (value is! Map) {
+      throw const FormatException('Invalid mTLS response event');
+    }
+    final requestId = value['requestId'];
+    final type = value['type'];
+    if (requestId is! String || type is! String) {
+      throw const FormatException('Invalid mTLS response event');
+    }
+    switch (type) {
+      case 'data':
+        final data = value['data'];
+        if (data is Uint8List) return MtlsDataEvent(requestId, data);
+        if (data is List) {
+          return MtlsDataEvent(requestId, Uint8List.fromList(data.cast<int>()));
+        }
+        throw const FormatException('Invalid mTLS response data');
+      case 'done':
+        return MtlsDoneEvent(requestId);
+      case 'error':
+        return MtlsErrorEvent(
+          requestId,
+          value['message'] is String
+              ? value['message'] as String
+              : 'The mTLS request failed.',
+        );
+      case 'websocketData':
+        final data = value['data'];
+        if (data is! String) {
+          throw const FormatException('Invalid mTLS WebSocket data');
+        }
+        return MtlsWebSocketDataEvent(requestId, data);
+      case 'websocketClosed':
+        final code = value['code'];
+        final reason = value['reason'];
+        if (code is! int || reason is! String) {
+          throw const FormatException('Invalid mTLS WebSocket close event');
+        }
+        return MtlsWebSocketClosedEvent(requestId, code: code, reason: reason);
+      case 'websocketError':
+        return MtlsWebSocketErrorEvent(
+          requestId,
+          value['message'] is String
+              ? value['message'] as String
+              : 'The secure WebSocket connection failed.',
+        );
+      default:
+        throw const FormatException('Unknown mTLS response event');
+    }
+  }
+
+  static void _requireAndroid() {
+    if (defaultTargetPlatform != TargetPlatform.android) {
+      throw UnsupportedError('mTLS gateway connections require Android.');
+    }
+  }
+}
+
+class MtlsWebSocketChannel implements GatewayWebSocketChannel {
+  static const _uuid = Uuid();
+
+  final String alias;
+  final MtlsWebSocketTransport transport;
+  final String _socketId = _uuid.v4();
+  final StreamController<dynamic> _controller = StreamController<dynamic>();
+  final Completer<void> _readyCompleter = Completer<void>();
+  final Completer<void> _doneCompleter = Completer<void>();
+  late final StreamSubscription<MtlsResponseEvent> _eventSubscription;
+  late final _MtlsWebSocketSink _sink;
+  Future<void> _sendChain = Future.value();
+  bool _closing = false;
+  bool _closed = false;
+
+  MtlsWebSocketChannel._({
+    required this.alias,
+    required this.transport,
+    required Uri url,
+  }) {
+    _sink = _MtlsWebSocketSink(this);
+    _eventSubscription = transport.events.listen(
+      _handleEvent,
+      onError: _handleTransportError,
+    );
+    unawaited(_start(url));
+  }
+
+  factory MtlsWebSocketChannel.connect(
+    Uri url, {
+    required String alias,
+    MtlsWebSocketTransport? transport,
+  }) {
+    if (url.scheme.toLowerCase() != 'wss') {
+      throw ArgumentError.value(url, 'url', 'mTLS WebSockets require WSS');
+    }
+    return MtlsWebSocketChannel._(
+      alias: alias,
+      transport: transport ?? MethodChannelMtlsTransport.instance,
+      url: url,
+    );
+  }
+
+  Future<void> _start(Uri url) async {
+    try {
+      await transport.startWebSocket(
+        socketId: _socketId,
+        alias: alias,
+        url: url,
+      );
+      if (!_readyCompleter.isCompleted) _readyCompleter.complete();
+    } catch (error, stackTrace) {
+      _fail(error, stackTrace);
+    }
+  }
+
+  @override
+  Future<void> get ready => _readyCompleter.future;
+
+  @override
+  StreamSink<dynamic> get sink => _sink;
+
+  @override
+  Stream<dynamic> get stream => _controller.stream;
+
+  Future<void> _enqueue(Object? data) {
+    if (_closing || _closed) {
+      return Future.error(StateError('The WebSocket is closing.'));
+    }
+    if (data is! String) {
+      return Future.error(
+        ArgumentError.value(data, 'data', 'Only text messages are supported'),
+      );
+    }
+    _sendChain = _sendChain.then((_) async {
+      await ready;
+      if (_closed) throw StateError('The WebSocket is closed.');
+      await transport.sendWebSocket(socketId: _socketId, data: data);
+    });
+    _sendChain.catchError(_fail);
+    return _sendChain;
+  }
+
+  Future<void> _close([int? code, String? reason]) async {
+    if (_closed || _closing) return _doneCompleter.future;
+    _closing = true;
+    try {
+      await transport
+          .closeWebSocket(
+            socketId: _socketId,
+            code: code ?? 1000,
+            reason: reason ?? '',
+          )
+          .timeout(const Duration(seconds: 5));
+    } catch (_) {
+      // Local teardown must not wait indefinitely for a dead native socket.
+    }
+    _finish();
+    return _doneCompleter.future;
+  }
+
+  void _handleEvent(MtlsResponseEvent event) {
+    if (event.requestId != _socketId || _closed) return;
+    switch (event) {
+      case MtlsWebSocketDataEvent():
+        _controller.add(event.data);
+      case MtlsWebSocketClosedEvent():
+        _finish();
+      case MtlsWebSocketErrorEvent():
+        _fail(StateError(event.message));
+      case MtlsDataEvent() || MtlsDoneEvent() || MtlsErrorEvent():
+        return;
+    }
+  }
+
+  void _handleTransportError(Object error, StackTrace stackTrace) {
+    _fail(error, stackTrace);
+  }
+
+  void _fail(Object error, [StackTrace? stackTrace]) {
+    if (_closed) return;
+    if (!_readyCompleter.isCompleted) {
+      _readyCompleter.completeError(error, stackTrace);
+    }
+    _controller.addError(error, stackTrace);
+    _finish();
+  }
+
+  void _finish() {
+    if (_closed) return;
+    _closed = true;
+    if (!_readyCompleter.isCompleted) {
+      _readyCompleter.completeError(
+        StateError('The secure WebSocket closed before connecting.'),
+      );
+    }
+    unawaited(_eventSubscription.cancel());
+    unawaited(_controller.close());
+    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
+  }
+}
+
+class _MtlsWebSocketSink implements StreamSink<dynamic> {
+  final MtlsWebSocketChannel _channel;
+
+  const _MtlsWebSocketSink(this._channel);
+
+  @override
+  void add(dynamic data) {
+    unawaited(_channel._enqueue(data));
+  }
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {
+    _channel._fail(error, stackTrace);
+  }
+
+  @override
+  Future<void> addStream(Stream<dynamic> stream) async {
+    await for (final data in stream) {
+      await _channel._enqueue(data);
+    }
+  }
+
+  @override
+  Future<void> close() => _channel._close();
+
+  @override
+  Future<void> get done => _channel._doneCompleter.future;
+}
+
+class GatewayHttpClientFactory {
+  static http.Client create(
+    SavedConnection connection, {
+    MtlsTransport? mtlsTransport,
+  }) {
+    if (!connection.mtlsEnabled) return http.Client();
+    final alias = connection.mtlsCertificateAlias?.trim();
+    if (alias == null || alias.isEmpty) {
+      return _UnavailableMtlsHttpClient();
+    }
+    return MtlsHttpClient(
+      alias: alias,
+      transport: mtlsTransport ?? MethodChannelMtlsTransport.instance,
+    );
+  }
+}
+
+class MtlsHttpClient extends http.BaseClient {
+  static const _uuid = Uuid();
+
+  final String alias;
+  final MtlsTransport transport;
+  final Map<String, StreamController<List<int>>> _responses = {};
+  final Set<String> _cancelledRequestIds = {};
+  late final StreamSubscription<MtlsResponseEvent> _eventSubscription;
+  bool _closed = false;
+
+  MtlsHttpClient({required this.alias, required this.transport}) {
+    _eventSubscription = transport.events.listen(
+      _handleEvent,
+      onError: _handleTransportError,
+    );
+  }
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    if (_closed) throw StateError('The mTLS HTTP client is closed.');
+    if (request.url.scheme.toLowerCase() != 'https') {
+      throw ArgumentError.value(
+        request.url,
+        'request.url',
+        'mTLS requests require HTTPS',
+      );
+    }
+
+    final requestId = _uuid.v4();
+    late final StreamController<List<int>> responseController;
+    responseController = StreamController<List<int>>(
+      onCancel: () async {
+        if (_responses.remove(requestId) != null) {
+          await transport.cancelRequest(requestId);
+        }
+      },
+    );
+    _responses[requestId] = responseController;
+
+    try {
+      final body = await request.finalize().toBytes();
+      if (_cancelledRequestIds.remove(requestId)) {
+        throw http.ClientException(
+          'The mTLS request was cancelled.',
+          request.url,
+        );
+      }
+      final head = await transport.startRequest(
+        MtlsRequest(
+          requestId: requestId,
+          alias: alias,
+          method: request.method,
+          url: request.url,
+          headers: Map<String, String>.from(request.headers),
+          body: body.isEmpty ? null : Uint8List.fromList(body),
+        ),
+      );
+      if (_cancelledRequestIds.remove(requestId)) {
+        throw http.ClientException(
+          'The mTLS request was cancelled.',
+          request.url,
+        );
+      }
+      return http.StreamedResponse(
+        responseController.stream,
+        head.statusCode,
+        contentLength: head.contentLength,
+        request: request,
+        headers: head.headers,
+        reasonPhrase: head.reasonPhrase,
+        isRedirect: head.statusCode >= 300 && head.statusCode < 400,
+      );
+    } catch (_) {
+      _cancelledRequestIds.remove(requestId);
+      _responses.remove(requestId);
+      if (!responseController.isClosed) {
+        unawaited(responseController.close());
+      }
+
+      rethrow;
+    }
+  }
+
+  void _handleEvent(MtlsResponseEvent event) {
+    final controller = _responses[event.requestId];
+    if (controller == null || controller.isClosed) return;
+    switch (event) {
+      case MtlsDataEvent():
+        controller.add(event.data);
+      case MtlsDoneEvent():
+        _cancelledRequestIds.remove(event.requestId);
+        _responses.remove(event.requestId);
+        unawaited(controller.close());
+      case MtlsErrorEvent():
+        _cancelledRequestIds.remove(event.requestId);
+        _responses.remove(event.requestId);
+        controller.addError(http.ClientException(event.message));
+        unawaited(controller.close());
+      case MtlsWebSocketDataEvent() ||
+          MtlsWebSocketClosedEvent() ||
+          MtlsWebSocketErrorEvent():
+        return;
+    }
+  }
+
+  void _handleTransportError(Object error, StackTrace stackTrace) {
+    final controllers = _responses.values.toList();
+    _responses.clear();
+    for (final controller in controllers) {
+      if (!controller.isClosed) {
+        controller.addError(error, stackTrace);
+        unawaited(controller.close());
+      }
+    }
+  }
+
+  Future<bool> cancelPendingRequests() async {
+    final requestIds = _responses.keys.toList();
+    if (requestIds.isEmpty) return false;
+    _cancelledRequestIds.addAll(requestIds);
+    await Future.wait(
+      requestIds.map(transport.cancelRequest),
+      eagerError: false,
+    );
+    return true;
+  }
+
+  @override
+  void close() {
+    if (_closed) return;
+    _closed = true;
+    final requestIds = _responses.keys.toList();
+    _cancelledRequestIds.addAll(requestIds);
+    final controllers = _responses.values.toList();
+    _responses.clear();
+    for (final requestId in requestIds) {
+      unawaited(transport.cancelRequest(requestId));
+    }
+    for (final controller in controllers) {
+      if (!controller.isClosed) unawaited(controller.close());
+    }
+    unawaited(_eventSubscription.cancel());
+  }
+}
+
+class _UnavailableMtlsHttpClient extends http.BaseClient {
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    throw StateError('The mTLS connection has no selected certificate.');
+  }
+}

--- a/lib/core/services/websocket_transport.dart
+++ b/lib/core/services/websocket_transport.dart
@@ -1,0 +1,30 @@
+import 'dart:async';
+
+import 'package:web_socket_channel/io.dart';
+
+abstract interface class GatewayWebSocketChannel {
+  Stream<dynamic> get stream;
+
+  StreamSink<dynamic> get sink;
+
+  Future<void> get ready;
+}
+
+typedef GatewayWebSocketChannelFactory =
+    GatewayWebSocketChannel Function(Uri uri);
+
+class IoGatewayWebSocketChannel implements GatewayWebSocketChannel {
+  final IOWebSocketChannel _channel;
+
+  IoGatewayWebSocketChannel.connect(Uri uri)
+    : _channel = IOWebSocketChannel.connect(uri);
+
+  @override
+  Future<void> get ready => _channel.ready;
+
+  @override
+  StreamSink<dynamic> get sink => _channel.sink;
+
+  @override
+  Stream<dynamic> get stream => _channel.stream;
+}

--- a/lib/core/services/ws_client.dart
+++ b/lib/core/services/ws_client.dart
@@ -6,7 +6,8 @@
 // a JSON-RPC response with the same id.
 import 'dart:async';
 import 'dart:convert';
-import 'package:web_socket_channel/io.dart';
+
+import 'websocket_transport.dart';
 
 Object? _deepFreezeJson(Object? value) {
   if (value is Map) {
@@ -153,7 +154,8 @@ class WsClient {
   final String baseUrl;
   final String? _token;
   final String? _ticket;
-  IOWebSocketChannel? _channel;
+  final GatewayWebSocketChannelFactory _channelFactory;
+  GatewayWebSocketChannel? _channel;
   bool _connected = false;
   int _nextId = 1;
   int _connectionGeneration = 0;
@@ -180,11 +182,21 @@ class WsClient {
   ConnectionCallback? onConnectionChanged;
   GatewayReadyCallback? onGatewayReady;
 
-  factory WsClient(String baseUrl, {String? token, String? ticket}) {
-    return WsClient._(baseUrl, token, ticket);
+  factory WsClient(
+    String baseUrl, {
+    String? token,
+    String? ticket,
+    GatewayWebSocketChannelFactory? channelFactory,
+  }) {
+    return WsClient._(
+      baseUrl,
+      token,
+      ticket,
+      channelFactory ?? IoGatewayWebSocketChannel.connect,
+    );
   }
 
-  WsClient._(this.baseUrl, this._token, this._ticket);
+  WsClient._(this.baseUrl, this._token, this._ticket, this._channelFactory);
 
   /// Connect to the WebSocket gateway.
   Future<void> connect() async {
@@ -202,7 +214,7 @@ class WsClient {
     // Observe that error future immediately; the waiter still receives it.
     readyCompleter.future.ignore();
     final wsUrl = buildWebSocketUrl(baseUrl, token: _token, ticket: _ticket);
-    final channel = IOWebSocketChannel.connect(Uri.parse(wsUrl));
+    final channel = _channelFactory(Uri.parse(wsUrl));
     _channel = channel;
     channel.stream.listen(
       (message) => _handleMessage(message, generation),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'core/services/connection_manager.dart';
 import 'core/services/gateway_turn_application_controller.dart';
+import 'core/services/mtls_client.dart';
 import 'core/services/text_size_preference.dart';
 import 'core/screens/session_list_screen.dart';
 import 'core/utils/responsive.dart';
@@ -166,7 +168,8 @@ class HermesHeader extends StatelessWidget {
         children: [
           Text(
             'HERMES',
-            style: TextStyle(fontFamily: 'Cinzel', 
+            style: TextStyle(
+              fontFamily: 'Cinzel',
               fontSize: 28,
               fontWeight: FontWeight.w700,
               color: const Color(0xFFD4AF37),
@@ -284,10 +287,13 @@ class _HomeScreenState extends State<HomeScreen> {
               gatewayPrefix,
               dashboardPrefix,
               dashboardProxied = false,
+              dashboardUrl,
               desktopGatewayUrl,
               dashboardPort,
               dashboardUsername,
               dashboardPassword,
+              mtlsEnabled = false,
+              mtlsCertificateAlias,
             }) async {
               if (existing == null) {
                 await widget.connManager.saveConnection(
@@ -298,10 +304,13 @@ class _HomeScreenState extends State<HomeScreen> {
                   gatewayPrefix: gatewayPrefix,
                   dashboardPrefix: dashboardPrefix,
                   dashboardProxied: dashboardProxied,
+                  dashboardUrl: dashboardUrl,
                   desktopGatewayUrl: desktopGatewayUrl,
                   dashboardPort: dashboardPort,
                   dashboardUsername: dashboardUsername,
                   dashboardPassword: dashboardPassword,
+                  mtlsEnabled: mtlsEnabled,
+                  mtlsCertificateAlias: mtlsCertificateAlias,
                 );
               } else {
                 await widget.connManager.updateConnection(
@@ -313,10 +322,13 @@ class _HomeScreenState extends State<HomeScreen> {
                   gatewayPrefix: gatewayPrefix,
                   dashboardPrefix: dashboardPrefix,
                   dashboardProxied: dashboardProxied,
+                  dashboardUrl: dashboardUrl,
                   desktopGatewayUrl: desktopGatewayUrl,
                   dashboardPort: dashboardPort,
                   dashboardUsername: dashboardUsername,
                   dashboardPassword: dashboardPassword,
+                  mtlsEnabled: mtlsEnabled,
+                  mtlsCertificateAlias: mtlsCertificateAlias,
                 );
               }
               _refresh();
@@ -392,6 +404,13 @@ class _HomeScreenState extends State<HomeScreen> {
                   : () async {
                       final key = ctrl.text.trim();
                       if (key.isEmpty) return;
+                      if (!conn.useHttps) {
+                        setDialogState(() {
+                          error =
+                              'Gateway API keys require an https:// connection.';
+                        });
+                        return;
+                      }
 
                       setDialogState(() {
                         validating = true;
@@ -399,11 +418,8 @@ class _HomeScreenState extends State<HomeScreen> {
                       });
 
                       try {
-                        final baseUrl = conn.baseUrl;
-                        final client = ApiClient(
-                          baseUrl: baseUrl,
-                          apiKey: key,
-                          pathPrefix: conn.gatewayPrefix ?? '',
+                        final client = ApiClient.fromConnection(
+                          conn.copyWith(apiKey: key),
                         );
                         final ok = await client.healthCheck();
                         client.close();
@@ -457,6 +473,9 @@ class _HomeScreenState extends State<HomeScreen> {
     );
     final dashboardPrefixCtrl = TextEditingController(
       text: conn.dashboardPrefix ?? '',
+    );
+    final dashboardUrlCtrl = TextEditingController(
+      text: conn.dashboardUrl ?? '',
     );
     final portCtrl = TextEditingController(
       text: conn.dashboardPortOverride?.toString() ?? '',
@@ -537,6 +556,17 @@ class _HomeScreenState extends State<HomeScreen> {
                   autocorrect: false,
                   enabled: !validating,
                 ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: dashboardUrlCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'Dashboard URL (optional)',
+                    hintText: 'https://dashboard.example.com:443',
+                  ),
+                  keyboardType: TextInputType.url,
+                  autocorrect: false,
+                  enabled: !validating,
+                ),
                 const SizedBox(height: 8),
                 SwitchListTile(
                   value: proxied,
@@ -601,6 +631,18 @@ class _HomeScreenState extends State<HomeScreen> {
                       final pass = passCtrl.text.trim();
                       final gatewayPrefix = gatewayPrefixCtrl.text.trim();
                       final dashboardPrefix = dashboardPrefixCtrl.text.trim();
+                      final dashboardUrl = dashboardUrlCtrl.text.trim();
+                      if (!SavedConnection.isValidDashboardUrl(
+                        dashboardUrl,
+                        requireHttps: conn.mtlsEnabled,
+                      )) {
+                        setDialogState(() {
+                          error = conn.mtlsEnabled
+                              ? 'The dashboard URL must be a valid https:// URL.'
+                              : 'The dashboard URL must be a valid HTTP(S) URL.';
+                        });
+                        return;
+                      }
 
                       setDialogState(() {
                         validating = true;
@@ -608,10 +650,11 @@ class _HomeScreenState extends State<HomeScreen> {
                       });
 
                       if (gatewayPrefix != (conn.gatewayPrefix ?? '')) {
-                        final apiClient = ApiClient(
-                          baseUrl: conn.baseUrl,
-                          apiKey: conn.apiKey,
-                          pathPrefix: gatewayPrefix,
+                        final apiClient = ApiClient.fromConnection(
+                          conn.copyWith(
+                            gatewayPrefix: gatewayPrefix,
+                            clearGatewayPrefix: gatewayPrefix.isEmpty,
+                          ),
                         );
                         final ok = await apiClient.healthCheck();
                         apiClient.close();
@@ -627,14 +670,34 @@ class _HomeScreenState extends State<HomeScreen> {
                         }
                       }
 
-                      final client = DashboardClient(
-                        host: conn.host,
-                        port: port ?? conn.dashboardPort,
-                        useHttps: conn.useHttps,
-                        pathPrefix: dashboardPrefix,
-                        proxied: proxied,
-                        username: user.isEmpty ? null : user,
-                        password: pass.isEmpty ? null : pass,
+                      final dashboardConnection = conn.copyWith(
+                        dashboardUrl: dashboardUrl,
+                        clearDashboardUrl: dashboardUrl.isEmpty,
+                        dashboardPortOverride: port,
+                        clearDashboardPort: port == null,
+                        dashboardPrefix: dashboardPrefix,
+                        clearDashboardPrefix: dashboardPrefix.isEmpty,
+                        dashboardProxied: proxied,
+                        dashboardUsername: user,
+                        clearDashboardUsername: user.isEmpty,
+                        dashboardPassword: pass,
+                        clearDashboardPassword: pass.isEmpty,
+                      );
+                      if (user.isNotEmpty &&
+                          pass.isNotEmpty &&
+                          Uri.parse(
+                                dashboardConnection.dashboardBaseUrl,
+                              ).scheme.toLowerCase() !=
+                              'https') {
+                        setDialogState(() {
+                          error =
+                              'Dashboard credentials require an https:// URL.';
+                          validating = false;
+                        });
+                        return;
+                      }
+                      final client = DashboardClient.fromConnection(
+                        dashboardConnection,
                       );
                       try {
                         await client.getModelInfo();
@@ -643,6 +706,7 @@ class _HomeScreenState extends State<HomeScreen> {
                         await widget.connManager.updateDashboardAuth(
                           conn.id,
                           dashboardPort: port,
+                          dashboardUrl: dashboardUrl,
                           username: user,
                           password: pass,
                           gatewayPrefix: gatewayPrefix,
@@ -665,8 +729,8 @@ class _HomeScreenState extends State<HomeScreen> {
                         setDialogState(() {
                           error =
                               'Could not reach/authenticate the dashboard at '
-                              '${conn.host}:${port ?? conn.dashboardPort}. '
-                              'Check the port and credentials.';
+                              '${dashboardConnection.dashboardBaseUrl}. '
+                              'Check the URL, port and credentials.';
                           validating = false;
                         });
                       }
@@ -688,6 +752,7 @@ class _HomeScreenState extends State<HomeScreen> {
     ).whenComplete(() {
       gatewayPrefixCtrl.dispose();
       dashboardPrefixCtrl.dispose();
+      dashboardUrlCtrl.dispose();
       portCtrl.dispose();
       userCtrl.dispose();
       passCtrl.dispose();
@@ -753,7 +818,8 @@ class _HomeScreenState extends State<HomeScreen> {
       appBar: AppBar(
         title: Text(
           'HERMES',
-          style: TextStyle(fontFamily: 'Cinzel', 
+          style: TextStyle(
+            fontFamily: 'Cinzel',
             fontWeight: FontWeight.w700,
             letterSpacing: 6,
             fontSize: 22,
@@ -824,10 +890,13 @@ class _AddDialog extends StatefulWidget {
     String? gatewayPrefix,
     String? dashboardPrefix,
     bool dashboardProxied,
+    String? dashboardUrl,
     String? desktopGatewayUrl,
     int? dashboardPort,
     String? dashboardUsername,
     String? dashboardPassword,
+    bool mtlsEnabled,
+    String? mtlsCertificateAlias,
   })
   onSave;
   const _AddDialog({required this.onSave, this.initialConnection});
@@ -843,12 +912,16 @@ class _AddDialogState extends State<_AddDialog> {
   late final TextEditingController _apiKey;
   late final TextEditingController _gatewayPrefix;
   late final TextEditingController _dashboardPrefix;
+  late final TextEditingController _dashboardUrl;
   late final TextEditingController _dashPort;
   late final TextEditingController _dashUser;
   late final TextEditingController _dashPass;
   late final TextEditingController _desktopGatewayUrl;
   late bool _showDashboard;
   late bool _dashboardProxied;
+  late bool _mtlsEnabled;
+  MtlsCertificate? _mtlsCertificate;
+  bool _selectingCertificate = false;
   bool _validating = false;
   String? _error;
 
@@ -870,23 +943,86 @@ class _AddDialogState extends State<_AddDialog> {
     _apiKey = TextEditingController(text: conn?.apiKey ?? '');
     _gatewayPrefix = TextEditingController(text: conn?.gatewayPrefix ?? '');
     _dashboardPrefix = TextEditingController(text: conn?.dashboardPrefix ?? '');
+    _dashboardUrl = TextEditingController(text: conn?.dashboardUrl ?? '');
     _dashPort = TextEditingController(
       text: conn?.dashboardPortOverride?.toString() ?? '',
     );
     _dashUser = TextEditingController(text: conn?.dashboardUsername ?? '');
     _dashPass = TextEditingController(text: conn?.dashboardPassword ?? '');
     _desktopGatewayUrl = TextEditingController(
-      text: conn?.desktopGatewayUrl ?? 'http://192.168.1.193/desktop',
+      text: conn?.desktopGatewayUrl ?? '',
     );
     _dashboardProxied = conn?.dashboardProxied ?? false;
+    _mtlsEnabled = conn?.mtlsEnabled ?? false;
+    final alias = conn?.mtlsCertificateAlias;
+    if (alias != null && alias.isNotEmpty) {
+      _mtlsCertificate = MtlsCertificate(alias: alias, label: alias);
+      unawaited(_restoreCertificateDescription(alias));
+    }
     _showDashboard =
         conn?.gatewayPrefix?.isNotEmpty == true ||
         conn?.dashboardPrefix?.isNotEmpty == true ||
+        conn?.dashboardUrl?.isNotEmpty == true ||
         conn?.dashboardPortOverride != null ||
         conn?.dashboardUsername?.isNotEmpty == true ||
         conn?.dashboardPassword?.isNotEmpty == true ||
         _dashboardProxied ||
         conn?.desktopGatewayUrl?.isNotEmpty == true;
+  }
+
+  Future<void> _restoreCertificateDescription(String alias) async {
+    try {
+      final certificate = await MethodChannelMtlsTransport.instance
+          .describeCertificate(alias);
+      if (!mounted || certificate == null) return;
+      setState(() => _mtlsCertificate = certificate);
+    } catch (_) {
+      // Keep the remembered alias visible; a request will surface if it is stale.
+    }
+  }
+
+  Future<void> _selectCertificate() async {
+    if (_selectingCertificate) return;
+    setState(() {
+      _selectingCertificate = true;
+      _error = null;
+    });
+    try {
+      final port = int.tryParse(_port.text.trim()) ?? 8642;
+      final normalized = SavedConnection.normalizeHostAndPort(_host.text, port);
+      final certificate = await MethodChannelMtlsTransport.instance
+          .chooseCertificate(
+            host: normalized.host.isEmpty ? null : normalized.host,
+            port: normalized.port,
+            alias: _mtlsCertificate?.alias,
+          );
+      if (!mounted) return;
+      if (certificate != null) {
+        setState(() => _mtlsCertificate = certificate);
+      }
+    } on UnsupportedError {
+      if (!mounted) return;
+      setState(() {
+        _error = 'mTLS certificate selection is available only on Android.';
+      });
+    } on PlatformException {
+      if (!mounted) return;
+      setState(() {
+        _error = 'The Android certificate picker could not be opened.';
+      });
+    } finally {
+      if (mounted) setState(() => _selectingCertificate = false);
+    }
+  }
+
+  void _setMtlsEnabled(bool enabled) {
+    setState(() {
+      _mtlsEnabled = enabled;
+      _error = null;
+    });
+    if (enabled && _mtlsCertificate == null) {
+      unawaited(_selectCertificate());
+    }
   }
 
   Future<void> _validateAndSave() async {
@@ -896,8 +1032,39 @@ class _AddDialogState extends State<_AddDialog> {
     final apiKey = _apiKey.text.trim();
     final gatewayPrefix = _gatewayPrefix.text.trim();
     final dashboardPrefix = _dashboardPrefix.text.trim();
+    final dashboardUrl = _dashboardUrl.text.trim();
 
     if (label.isEmpty || host.isEmpty || port <= 0) return;
+    final normalized = SavedConnection.normalizeHostAndPort(host, port);
+    if (apiKey.isNotEmpty && !normalized.useHttps) {
+      setState(() {
+        _error = 'Gateway API keys require an explicit https:// host.';
+      });
+      return;
+    }
+    if (_mtlsEnabled && !host.toLowerCase().startsWith('https://')) {
+      setState(() {
+        _error = 'mTLS requires an explicit https:// Gateway host.';
+      });
+      return;
+    }
+    if (_mtlsEnabled && _mtlsCertificate == null) {
+      setState(() {
+        _error = 'Select an installed certificate before connecting with mTLS.';
+      });
+      return;
+    }
+    if (!SavedConnection.isValidDashboardUrl(
+      dashboardUrl,
+      requireHttps: _mtlsEnabled,
+    )) {
+      setState(() {
+        _error = _mtlsEnabled
+            ? 'The dashboard URL must be a valid https:// URL.'
+            : 'The dashboard URL must be a valid HTTP(S) URL.';
+      });
+      return;
+    }
 
     setState(() {
       _validating = true;
@@ -905,20 +1072,68 @@ class _AddDialogState extends State<_AddDialog> {
     });
 
     try {
-      final normalized = SavedConnection.normalizeHostAndPort(host, port);
-      final baseUrl = SavedConnection(
-        id: '',
-        label: '',
+      final dashPortText = _dashPort.text.trim();
+      final dashUser = _dashUser.text.trim();
+      final dashPass = _dashPass.text.trim();
+      final desktopGatewayUrl = _desktopGatewayUrl.text.trim();
+      if (desktopGatewayUrl.isNotEmpty) {
+        final normalizedDesktopUrl = desktopGatewayUrl.contains('://')
+            ? desktopGatewayUrl
+            : 'https://$desktopGatewayUrl';
+        final desktopUri = Uri.tryParse(normalizedDesktopUrl);
+        final validScheme =
+            desktopUri?.scheme == 'http' || desktopUri?.scheme == 'https';
+        if (desktopUri == null ||
+            desktopUri.host.isEmpty ||
+            !validScheme ||
+            desktopUri.scheme != 'https') {
+          setState(() {
+            _error =
+                'The Desktop Gateway URL must be a valid https:// URL because it carries session credentials.';
+            _validating = false;
+          });
+          return;
+        }
+      }
+      final dashPort = dashPortText.isEmpty ? null : int.tryParse(dashPortText);
+      if (dashPortText.isNotEmpty &&
+          (dashPort == null || dashPort <= 0 || dashPort > 65535)) {
+        setState(() {
+          _error = 'Invalid dashboard port number.';
+          _validating = false;
+        });
+        return;
+      }
+      final validationConnection = SavedConnection(
+        id: widget.initialConnection?.id ?? '',
+        label: label,
         host: normalized.host,
         port: normalized.port,
-        apiKey: '',
-        useHttps: normalized.useHttps,
-      ).baseUrl;
-      final client = ApiClient(
-        baseUrl: baseUrl,
         apiKey: apiKey,
-        pathPrefix: gatewayPrefix,
+        useHttps: normalized.useHttps,
+        mtlsEnabled: _mtlsEnabled,
+        mtlsCertificateAlias: _mtlsEnabled ? _mtlsCertificate!.alias : null,
+        gatewayPrefix: gatewayPrefix.isEmpty ? null : gatewayPrefix,
+        dashboardPrefix: dashboardPrefix.isEmpty ? null : dashboardPrefix,
+        dashboardUrl: dashboardUrl,
+        dashboardProxied: _dashboardProxied,
+        dashboardPortOverride: dashPort,
+        dashboardUsername: dashUser.isEmpty ? null : dashUser,
+        dashboardPassword: dashPass.isEmpty ? null : dashPass,
       );
+      if (dashUser.isNotEmpty &&
+          dashPass.isNotEmpty &&
+          Uri.parse(
+                validationConnection.dashboardBaseUrl,
+              ).scheme.toLowerCase() !=
+              'https') {
+        setState(() {
+          _error = 'Dashboard credentials require an https:// URL.';
+          _validating = false;
+        });
+        return;
+      }
+      final client = ApiClient.fromConnection(validationConnection);
       final ok = await client.healthCheck();
       client.close();
 
@@ -926,19 +1141,15 @@ class _AddDialogState extends State<_AddDialog> {
 
       if (!ok) {
         setState(() {
-          _error = apiKey.isEmpty
+          _error = _mtlsEnabled
+              ? 'Gateway rejected the selected certificate or API key.'
+              : apiKey.isEmpty
               ? 'Server requires an API key. Enter your API_SERVER_KEY.'
               : 'Invalid API key. Server returned 401.';
           _validating = false;
         });
         return;
       }
-
-      final dashPortText = _dashPort.text.trim();
-      final dashUser = _dashUser.text.trim();
-      final dashPass = _dashPass.text.trim();
-      final desktopGatewayUrl = _desktopGatewayUrl.text.trim();
-      final dashPort = dashPortText.isEmpty ? null : int.tryParse(dashPortText);
 
       // If the user supplied any dashboard details, validate them before saving
       // (parity with the Dashboard Login dialog). The gateway is already known
@@ -947,24 +1158,9 @@ class _AddDialogState extends State<_AddDialog> {
           dashUser.isNotEmpty ||
           dashPass.isNotEmpty ||
           dashboardPrefix.isNotEmpty ||
+          dashboardUrl.isNotEmpty ||
           _dashboardProxied) {
-        final dashClient = DashboardClient(
-          host: normalized.host,
-          port: SavedConnection(
-            id: '',
-            label: '',
-            host: normalized.host,
-            port: normalized.port,
-            apiKey: '',
-            useHttps: normalized.useHttps,
-            dashboardPortOverride: dashPort,
-          ).dashboardPort,
-          useHttps: normalized.useHttps,
-          pathPrefix: dashboardPrefix,
-          proxied: _dashboardProxied,
-          username: dashUser.isEmpty ? null : dashUser,
-          password: dashPass.isEmpty ? null : dashPass,
-        );
+        final dashClient = DashboardClient.fromConnection(validationConnection);
         try {
           await dashClient.getModelInfo();
         } catch (_) {
@@ -991,10 +1187,13 @@ class _AddDialogState extends State<_AddDialog> {
         gatewayPrefix: gatewayPrefix.isEmpty ? null : gatewayPrefix,
         dashboardPrefix: dashboardPrefix.isEmpty ? null : dashboardPrefix,
         dashboardProxied: _dashboardProxied,
+        dashboardUrl: dashboardUrl.isEmpty ? null : dashboardUrl,
         desktopGatewayUrl: desktopGatewayUrl.isEmpty ? null : desktopGatewayUrl,
         dashboardPort: dashPort,
         dashboardUsername: dashUser.isEmpty ? null : dashUser,
         dashboardPassword: dashPass.isEmpty ? null : dashPass,
+        mtlsEnabled: _mtlsEnabled,
+        mtlsCertificateAlias: _mtlsEnabled ? _mtlsCertificate!.alias : null,
       );
       if (mounted) Navigator.pop(context);
     } on CredentialStorageException {
@@ -1083,6 +1282,43 @@ class _AddDialogState extends State<_AddDialog> {
               ),
               obscureText: true,
             ),
+            const SizedBox(height: 8),
+            SwitchListTile(
+              value: _mtlsEnabled,
+              contentPadding: EdgeInsets.zero,
+              title: const Text('mTLS (optional)'),
+              subtitle: const Text(
+                'Use an installed certificate for Gateway API calls',
+              ),
+              onChanged: _validating || _selectingCertificate
+                  ? null
+                  : _setMtlsEnabled,
+            ),
+            if (_mtlsEnabled)
+              ListTile(
+                contentPadding: EdgeInsets.zero,
+                leading: const Icon(Icons.badge_outlined),
+                title: Text(
+                  _mtlsCertificate?.label ?? 'No certificate selected',
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                subtitle: _mtlsCertificate == null
+                    ? const Text('A certificate is required for mTLS')
+                    : const Text('Android system certificate'),
+                trailing: _selectingCertificate
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : TextButton(
+                        onPressed: _validating ? null : _selectCertificate,
+                        child: Text(
+                          _mtlsCertificate == null ? 'Select' : 'Change',
+                        ),
+                      ),
+              ),
             const SizedBox(height: 4),
             InkWell(
               onTap: _validating
@@ -1124,6 +1360,18 @@ class _AddDialogState extends State<_AddDialog> {
                   labelText: 'Dashboard path prefix',
                   hintText: 'e.g. /dashboard (proxy path before /api/)',
                 ),
+                autocorrect: false,
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _dashboardUrl,
+                decoration: const InputDecoration(
+                  labelText: 'Dashboard URL (optional)',
+                  hintText: 'https://hermesdb.example.com:443',
+                  helperText:
+                      'Uses the selected mTLS certificate. If the URL omits a port, Dashboard Port is used.',
+                ),
+                keyboardType: TextInputType.url,
                 autocorrect: false,
               ),
               const SizedBox(height: 8),
@@ -1175,7 +1423,7 @@ class _AddDialogState extends State<_AddDialog> {
                   labelText: 'Desktop Gateway URL (optional)',
                   hintText: 'https://hermes-desktop.example.lan',
                   helperText:
-                      'Enables file attachments through the Desktop remote gateway.',
+                      'Enables full file attachments. Uses the selected mTLS certificate.',
                 ),
                 keyboardType: TextInputType.url,
                 autocorrect: false,
@@ -1214,6 +1462,7 @@ class _AddDialogState extends State<_AddDialog> {
     _apiKey.dispose();
     _gatewayPrefix.dispose();
     _dashboardPrefix.dispose();
+    _dashboardUrl.dispose();
     _dashPort.dispose();
     _dashUser.dispose();
     _dashPass.dispose();

--- a/test/connection_manager_test.dart
+++ b/test/connection_manager_test.dart
@@ -307,6 +307,60 @@ void main() {
       expect(https.dashboardPort, 8443);
     });
 
+    test('separate dashboard URL overrides the Gateway host and port', () {
+      final connection = SavedConnection(
+        id: '1',
+        label: 'Hosted',
+        host: 'gateway.example.com',
+        port: 42849,
+        apiKey: 'key',
+        useHttps: true,
+        dashboardUrl: 'https://dashboard.example.com:42848',
+        dashboardPrefix: '/admin',
+      );
+
+      expect(
+        connection.dashboardBaseUrl,
+        'https://dashboard.example.com:42848/admin',
+      );
+      final restored = SavedConnection.fromMap(connection.toMap());
+      expect(restored.dashboardUrl, 'https://dashboard.example.com:42848');
+      expect(restored.dashboardBaseUrl, connection.dashboardBaseUrl);
+    });
+
+    test('dashboard port applies when the separate URL omits its port', () {
+      final connection = SavedConnection(
+        id: '1',
+        label: 'Hosted',
+        host: 'gateway.example.com',
+        port: 42849,
+        apiKey: 'key',
+        useHttps: true,
+        dashboardUrl: 'https://dashboard.example.com',
+        dashboardPortOverride: 42848,
+      );
+
+      expect(
+        connection.dashboardBaseUrl,
+        'https://dashboard.example.com:42848',
+      );
+    });
+
+    test('port in the separate dashboard URL wins over the port field', () {
+      final connection = SavedConnection(
+        id: '1',
+        label: 'Hosted',
+        host: 'gateway.example.com',
+        port: 42849,
+        apiKey: 'key',
+        useHttps: true,
+        dashboardUrl: 'https://dashboard.example.com:8443',
+        dashboardPortOverride: 42848,
+      );
+
+      expect(connection.dashboardBaseUrl, 'https://dashboard.example.com:8443');
+    });
+
     test('serializes dashboard metadata without plaintext credentials', () {
       final conn = SavedConnection(
         id: '1',
@@ -807,12 +861,14 @@ void main() {
         '192.168.1.50',
         8642,
         'key',
+        dashboardUrl: 'https://dashboard.example.com:30433',
         dashboardPort: 30433,
         dashboardUsername: 'misha',
         dashboardPassword: 'secret',
       );
 
       final conn = mgr.getConnections().single;
+      expect(conn.dashboardUrl, 'https://dashboard.example.com:30433');
       expect(conn.dashboardPortOverride, 30433);
       expect(conn.dashboardUsername, 'misha');
       expect(conn.dashboardPassword, 'secret');
@@ -831,6 +887,7 @@ void main() {
         id,
         gatewayPrefix: '/profile/peter',
         dashboardPrefix: '/dashboard',
+        dashboardUrl: 'https://dashboard.example.com:30433',
         dashboardProxied: true,
         dashboardPort: 30433,
         username: 'misha',
@@ -839,6 +896,7 @@ void main() {
       var conn = mgr.getConnections().single;
       expect(conn.gatewayPrefix, '/profile/peter');
       expect(conn.dashboardPrefix, '/dashboard');
+      expect(conn.dashboardUrl, 'https://dashboard.example.com:30433');
       expect(conn.dashboardProxied, isTrue);
       expect(conn.dashboardPortOverride, 30433);
       expect(conn.dashboardUsername, 'misha');
@@ -849,6 +907,7 @@ void main() {
         id,
         gatewayPrefix: '',
         dashboardPrefix: '',
+        dashboardUrl: '',
         dashboardProxied: false,
         username: '',
         password: '',
@@ -856,6 +915,7 @@ void main() {
       conn = mgr.getConnections().single;
       expect(conn.gatewayPrefix, isNull);
       expect(conn.dashboardPrefix, isNull);
+      expect(conn.dashboardUrl, isNull);
       expect(conn.dashboardProxied, isFalse);
       expect(conn.dashboardPortOverride, isNull);
       expect(conn.dashboardUsername, isNull);

--- a/test/gateway_turn_application_controller_test.dart
+++ b/test/gateway_turn_application_controller_test.dart
@@ -49,14 +49,44 @@ void main() {
     await controller.close();
     expect(created.map((session) => session.closeCount), everyElement(1));
   });
+
+  test(
+    'changed mTLS certificate creates a distinct application scope',
+    () async {
+      final created = <_FakeApplicationSession>[];
+      final controller = GatewayTurnApplicationController(
+        sessionFactory: (_) {
+          final session = _FakeApplicationSession();
+          created.add(session);
+          return session;
+        },
+      );
+
+      final original = controller.sessionFor(
+        _connection(mtlsCertificateAlias: 'first-certificate'),
+      );
+      final changed = controller.sessionFor(
+        _connection(mtlsCertificateAlias: 'second-certificate'),
+      );
+
+      expect(identical(original, changed), isFalse);
+      expect(controller.retainedSessionCount, 2);
+      await controller.close();
+    },
+  );
 }
 
-SavedConnection _connection({String apiKey = 'secret'}) => SavedConnection(
+SavedConnection _connection({
+  String apiKey = 'secret',
+  String? mtlsCertificateAlias,
+}) => SavedConnection(
   id: 'remote-profile',
   label: 'Remote',
   host: '127.0.0.1',
   port: 8642,
   apiKey: apiKey,
+  mtlsEnabled: mtlsCertificateAlias != null,
+  mtlsCertificateAlias: mtlsCertificateAlias,
   desktopGatewayUrl: 'ws://127.0.0.1:8643/ws',
   dashboardUsername: 'operator',
   dashboardPassword: 'dashboard-secret',

--- a/test/mtls_client_test.dart
+++ b/test/mtls_client_test.dart
@@ -1,0 +1,620 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hermes_android/core/services/desktop_gateway_client.dart';
+import 'package:hermes_android/core/services/connection_manager.dart';
+import 'package:hermes_android/core/services/mtls_client.dart';
+
+class _FakeMtlsTransport implements MtlsTransport, MtlsWebSocketTransport {
+  final StreamController<MtlsResponseEvent> controller =
+      StreamController<MtlsResponseEvent>.broadcast();
+  final List<MtlsRequest> requests = [];
+  final List<String> cancelled = [];
+  bool autoComplete = true;
+  bool autoRespondWebSocket = false;
+  bool emitWebSocketClose = true;
+  Completer<MtlsResponseHead>? delayedResponseHead;
+  Completer<void>? delayedWebSocketStart;
+  String Function(MtlsRequest request)? responseBodyForRequest;
+  String? webSocketId;
+  String? webSocketAlias;
+  Uri? webSocketUrl;
+  final List<String> webSocketMessages = [];
+  int webSocketStarts = 0;
+  bool webSocketClosed = false;
+
+  @override
+  Stream<MtlsResponseEvent> get events => controller.stream;
+
+  @override
+  Future<bool> cancelRequest(String requestId) async {
+    cancelled.add(requestId);
+    final delayed = delayedResponseHead;
+    if (delayed != null && !delayed.isCompleted) {
+      delayed.completeError(StateError('cancelled'));
+    }
+    return true;
+  }
+
+  @override
+  Future<MtlsCertificate?> chooseCertificate({
+    String? host,
+    int? port,
+    String? alias,
+  }) async {
+    return const MtlsCertificate(alias: 'chosen', label: 'Chosen certificate');
+  }
+
+  @override
+  Future<MtlsCertificate?> describeCertificate(String alias) async {
+    return MtlsCertificate(alias: alias, label: 'Remembered certificate');
+  }
+
+  @override
+  Future<MtlsResponseHead> startRequest(MtlsRequest request) async {
+    requests.add(request);
+    final delayed = delayedResponseHead;
+    if (delayed != null) return delayed.future;
+    if (autoComplete) {
+      final responseBody =
+          responseBodyForRequest?.call(request) ?? '{"ok":true}';
+      scheduleMicrotask(() {
+        controller.add(
+          MtlsDataEvent(
+            request.requestId,
+            Uint8List.fromList(utf8.encode(responseBody)),
+          ),
+        );
+        controller.add(MtlsDoneEvent(request.requestId));
+      });
+    }
+    return const MtlsResponseHead(
+      statusCode: 200,
+      reasonPhrase: 'OK',
+      contentLength: null,
+      headers: {'content-type': 'application/json'},
+    );
+  }
+
+  @override
+  Future<void> startWebSocket({
+    required String socketId,
+    required String alias,
+    required Uri url,
+  }) async {
+    webSocketId = socketId;
+    webSocketAlias = alias;
+    webSocketUrl = url;
+    webSocketStarts++;
+    final delayed = delayedWebSocketStart;
+    if (delayed != null) await delayed.future;
+    if (autoRespondWebSocket) {
+      scheduleMicrotask(() {
+        controller.add(
+          MtlsWebSocketDataEvent(
+            socketId,
+            jsonEncode({
+              'jsonrpc': '2.0',
+              'method': 'event',
+              'params': {
+                'type': 'gateway.ready',
+                'data': {'methods': <String>[]},
+              },
+            }),
+          ),
+        );
+      });
+    }
+  }
+
+  @override
+  Future<void> sendWebSocket({
+    required String socketId,
+    required String data,
+  }) async {
+    webSocketMessages.add(data);
+    if (autoRespondWebSocket) {
+      final request = jsonDecode(data) as Map<String, dynamic>;
+      scheduleMicrotask(() {
+        controller.add(
+          MtlsWebSocketDataEvent(
+            socketId,
+            jsonEncode({
+              'jsonrpc': '2.0',
+              'id': request['id'],
+              'result': {
+                'session_id':
+                    (request['params'] as Map<String, dynamic>)['session_id'],
+              },
+            }),
+          ),
+        );
+      });
+    }
+  }
+
+  @override
+  Future<void> closeWebSocket({
+    required String socketId,
+    int code = 1000,
+    String reason = '',
+  }) async {
+    webSocketClosed = true;
+    if (emitWebSocketClose) {
+      scheduleMicrotask(() {
+        controller.add(
+          MtlsWebSocketClosedEvent(socketId, code: code, reason: reason),
+        );
+      });
+    }
+  }
+
+  Future<void> dispose() => controller.close();
+}
+
+SavedConnection _connection({
+  bool mtlsEnabled = true,
+  String? alias = 'client-cert',
+}) {
+  return SavedConnection(
+    id: 'connection-id',
+    label: 'Gateway',
+    host: 'gateway.example.com',
+    port: 443,
+    apiKey: 'synthetic-api-key',
+    useHttps: true,
+    mtlsEnabled: mtlsEnabled,
+    mtlsCertificateAlias: alias,
+  );
+}
+
+String? _header(Map<String, String> headers, String name) {
+  final lowerName = name.toLowerCase();
+  for (final entry in headers.entries) {
+    if (entry.key.toLowerCase() == lowerName) return entry.value;
+  }
+  return null;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('waits for the native event stream before starting a request', () async {
+    const channel = MethodChannel('com.hermesagent.hermes_android/mtls');
+    final calls = <String>[];
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call.method);
+          if (call.method == 'startRequest') {
+            return <String, Object?>{
+              'statusCode': 200,
+              'reasonPhrase': 'OK',
+              'contentLength': 0,
+              'headers': <String, String>{},
+            };
+          }
+          return null;
+        });
+    addTearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    await MethodChannelMtlsTransport.instance.startRequest(
+      MtlsRequest(
+        requestId: 'request-id',
+        alias: 'client-cert',
+        method: 'GET',
+        url: Uri.parse('https://gateway.example.com/api/sessions'),
+        headers: const {},
+        body: null,
+      ),
+    );
+
+    expect(calls, ['waitUntilEventStreamReady', 'startRequest']);
+  });
+
+  test('factory routes enabled connections through native mTLS transport', () {
+    final transport = _FakeMtlsTransport();
+    addTearDown(transport.dispose);
+
+    final enabled = GatewayHttpClientFactory.create(
+      _connection(),
+      mtlsTransport: transport,
+    );
+    final disabled = GatewayHttpClientFactory.create(
+      _connection(mtlsEnabled: false, alias: null),
+      mtlsTransport: transport,
+    );
+
+    expect(enabled, isA<MtlsHttpClient>());
+    expect(disabled, isNot(isA<MtlsHttpClient>()));
+    enabled.close();
+    disabled.close();
+  });
+
+  test('Gateway API keys are rejected over cleartext HTTP', () {
+    final connection = _connection(
+      mtlsEnabled: false,
+      alias: null,
+    ).copyWith(useHttps: false, port: 80);
+
+    expect(() => ApiClient.fromConnection(connection), throwsArgumentError);
+  });
+
+  test('unauthenticated Gateway connections may use local HTTP', () {
+    final connection = _connection(
+      mtlsEnabled: false,
+      alias: null,
+    ).copyWith(host: '127.0.0.1', port: 8642, apiKey: '', useHttps: false);
+
+    final client = ApiClient.fromConnection(connection);
+    client.close();
+  });
+
+  test('dashboard password authentication is rejected over HTTP', () {
+    final connection = _connection(mtlsEnabled: false, alias: null).copyWith(
+      dashboardUrl: 'http://dashboard.example.com:9119',
+      dashboardUsername: 'user',
+      dashboardPassword: 'password',
+    );
+
+    expect(
+      () => DashboardClient.fromConnection(connection),
+      throwsArgumentError,
+    );
+  });
+
+  test('open dashboards may use local HTTP', () {
+    final connection = _connection(mtlsEnabled: false, alias: null).copyWith(
+      dashboardUrl: 'http://127.0.0.1:9119',
+      clearDashboardUsername: true,
+      clearDashboardPassword: true,
+    );
+
+    final client = DashboardClient.fromConnection(connection);
+    client.close();
+  });
+
+  test(
+    'forwards API key, request body, and streamed native response',
+    () async {
+      final transport = _FakeMtlsTransport();
+      addTearDown(transport.dispose);
+      final client = ApiClient.fromConnection(
+        _connection(),
+        mtlsTransport: transport,
+      );
+      addTearDown(client.close);
+
+      final response = await client.apiPost(
+        'api/example',
+        body: {'message': 'hello'},
+      );
+
+      expect(response, {'ok': true});
+      expect(transport.requests, hasLength(1));
+      final request = transport.requests.single;
+      expect(request.alias, 'client-cert');
+      expect(
+        request.url,
+        Uri.parse('https://gateway.example.com:443/api/example'),
+      );
+      expect(
+        _header(request.headers, 'Authorization'),
+        contains('synthetic-api-key'),
+      );
+      expect(utf8.decode(request.body!), contains('"message":"hello"'));
+    },
+  );
+
+  test('routes a separate dashboard URL through native mTLS', () async {
+    final transport = _FakeMtlsTransport();
+    final connection = _connection().copyWith(
+      dashboardUrl: 'https://dashboard.example.com:8443',
+      dashboardProxied: true,
+    );
+    final client = DashboardClient.fromConnection(
+      connection,
+      mtlsTransport: transport,
+    );
+    addTearDown(() async {
+      client.close();
+      await Future<void>.delayed(Duration.zero);
+      await transport.dispose();
+    });
+
+    expect(await client.getModelInfo(), {'ok': true});
+    expect(transport.requests, hasLength(1));
+    expect(
+      transport.requests.single.url,
+      Uri.parse('https://dashboard.example.com:8443/api/model/info'),
+    );
+    expect(transport.requests.single.alias, 'client-cert');
+  });
+
+  test('combines a separate dashboard URL and port for native mTLS', () async {
+    final transport = _FakeMtlsTransport();
+    addTearDown(transport.dispose);
+    final connection = _connection().copyWith(
+      dashboardUrl: 'https://dashboard.example.com',
+      dashboardPortOverride: 42848,
+      dashboardProxied: true,
+    );
+    final client = DashboardClient.fromConnection(
+      connection,
+      mtlsTransport: transport,
+    );
+    addTearDown(client.close);
+
+    expect(await client.getModelInfo(), {'ok': true});
+    expect(
+      transport.requests.single.url,
+      Uri.parse('https://dashboard.example.com:42848/api/model/info'),
+    );
+    expect(transport.requests.single.alias, 'client-cert');
+  });
+
+  test('sends and receives Desktop Gateway WebSocket data with mTLS', () async {
+    final transport = _FakeMtlsTransport();
+    addTearDown(transport.dispose);
+    final channel = MtlsWebSocketChannel.connect(
+      Uri.parse('wss://desktop.example.com:42848/api/ws?ticket=one-use'),
+      alias: 'client-cert',
+      transport: transport,
+    );
+
+    await channel.ready;
+    expect(transport.webSocketAlias, 'client-cert');
+    expect(
+      transport.webSocketUrl,
+      Uri.parse('wss://desktop.example.com:42848/api/ws?ticket=one-use'),
+    );
+
+    await channel.sink.addStream(Stream.value('{"jsonrpc":"2.0"}'));
+    expect(transport.webSocketMessages, ['{"jsonrpc":"2.0"}']);
+
+    final response = channel.stream.first;
+    transport.controller.add(
+      MtlsWebSocketDataEvent(transport.webSocketId!, '{"result":"ok"}'),
+    );
+    expect(await response, '{"result":"ok"}');
+
+    final closed = channel.sink.close();
+    await closed;
+    expect(transport.webSocketClosed, isTrue);
+  });
+
+  test(
+    'closing an mTLS WebSocket does not wait for a stalled connect',
+    () async {
+      final delayedStart = Completer<void>();
+      final transport = _FakeMtlsTransport()
+        ..delayedWebSocketStart = delayedStart
+        ..emitWebSocketClose = false;
+      addTearDown(transport.dispose);
+      final channel = MtlsWebSocketChannel.connect(
+        Uri.parse('wss://desktop.example.com:42848/api/ws'),
+        alias: 'client-cert',
+        transport: transport,
+      );
+      channel.ready.ignore();
+      while (transport.webSocketId == null) {
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      await channel.sink.close().timeout(const Duration(seconds: 1));
+
+      expect(transport.webSocketClosed, isTrue);
+      delayedStart.complete();
+    },
+  );
+
+  test('open Desktop Gateway uses its SPA token with native mTLS', () async {
+    final transport = _FakeMtlsTransport()
+      ..autoRespondWebSocket = true
+      ..responseBodyForRequest = (_) =>
+          '<script>window.__HERMES_SESSION_TOKEN__="spa-token";</script>';
+    final connection = _connection().copyWith(
+      desktopGatewayUrl: 'https://desktop.example.com:42848',
+    );
+    final client = DesktopGatewayClient.fromConnection(
+      connection,
+      mtlsTransport: transport,
+      mtlsWebSocketTransport: transport,
+    );
+    addTearDown(() async {
+      client.close();
+      await Future<void>.delayed(Duration.zero);
+      await transport.dispose();
+    });
+
+    await client.ensureSession('mobile-session');
+
+    expect(transport.requests, hasLength(1));
+    expect(
+      transport.requests.single.url,
+      Uri.parse('https://desktop.example.com:42848/'),
+    );
+    expect(transport.requests.single.alias, 'client-cert');
+    expect(
+      transport.webSocketUrl,
+      Uri.parse('wss://desktop.example.com:42848/api/ws?token=spa-token'),
+    );
+    expect(transport.webSocketAlias, 'client-cert');
+  });
+
+  test(
+    'routes Desktop Gateway ticket and socket through native mTLS',
+    () async {
+      final transport = _FakeMtlsTransport()
+        ..autoRespondWebSocket = true
+        ..responseBodyForRequest = (request) {
+          if (request.url.path.endsWith('/api/auth/ws-ticket')) {
+            return '{"ticket":"one-use"}';
+          }
+          return '{"ok":true}';
+        };
+      final connection = _connection().copyWith(
+        desktopGatewayUrl: 'https://desktop.example.com:42848',
+        dashboardProxied: true,
+      );
+      final client = DesktopGatewayClient.fromConnection(
+        connection,
+        mtlsTransport: transport,
+        mtlsWebSocketTransport: transport,
+      );
+      addTearDown(() async {
+        client.close();
+        await Future<void>.delayed(Duration.zero);
+        await transport.dispose();
+      });
+
+      await Future.wait([
+        client.ensureSession('mobile-session'),
+        client.ensureSession('second-session'),
+      ]);
+
+      expect(transport.requests, hasLength(1));
+      expect(transport.webSocketStarts, 1);
+      expect(
+        transport.requests.single.url,
+        Uri.parse('https://desktop.example.com:42848/api/auth/ws-ticket'),
+      );
+      expect(transport.requests.single.alias, 'client-cert');
+      expect(
+        transport.webSocketUrl,
+        Uri.parse('wss://desktop.example.com:42848/api/ws?ticket=one-use'),
+      );
+      expect(transport.webSocketAlias, 'client-cert');
+      expect(transport.webSocketMessages, hasLength(2));
+      expect(
+        transport.webSocketMessages.map(
+          (message) => jsonDecode(message)['method'],
+        ),
+        everyElement('session.resume'),
+      );
+    },
+  );
+
+  test('closing Desktop Gateway during connect cannot resurrect it', () async {
+    final transport = _FakeMtlsTransport()
+      ..delayedResponseHead = Completer<MtlsResponseHead>();
+    final connection = _connection().copyWith(
+      desktopGatewayUrl: 'https://desktop.example.com:42848',
+      dashboardProxied: true,
+    );
+    final client = DesktopGatewayClient.fromConnection(
+      connection,
+      mtlsTransport: transport,
+      mtlsWebSocketTransport: transport,
+    );
+    final connecting = client.ensureSession('mobile-session');
+    while (transport.requests.isEmpty) {
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    client.close();
+
+    await expectLater(connecting, throwsA(anything));
+    expect(transport.webSocketStarts, 0);
+    await transport.dispose();
+  });
+
+  test('Desktop Gateway rejects a cleartext URL without mTLS', () {
+    final connection = _connection(
+      mtlsEnabled: false,
+      alias: null,
+    ).copyWith(desktopGatewayUrl: 'http://desktop.example.com:42848');
+
+    expect(
+      () => DesktopGatewayClient.fromConnection(connection),
+      throwsArgumentError,
+    );
+  });
+
+  test('rejects cleartext requests before invoking native transport', () async {
+    final transport = _FakeMtlsTransport();
+    addTearDown(transport.dispose);
+    final client = MtlsHttpClient(alias: 'client-cert', transport: transport);
+    addTearDown(client.close);
+
+    await expectLater(
+      client.get(Uri.parse('http://gateway.example.com/health')),
+      throwsArgumentError,
+    );
+    expect(transport.requests, isEmpty);
+  });
+
+  test('cancelling an SSE response cancels the native request', () async {
+    final transport = _FakeMtlsTransport()..autoComplete = false;
+    addTearDown(transport.dispose);
+    final api = ApiClient.fromConnection(
+      _connection(),
+      mtlsTransport: transport,
+    );
+    final gateway = GatewayChatClient(api);
+    addTearDown(gateway.abort);
+
+    final sending = gateway.sendMessageStreaming(
+      message: 'hello',
+      sessionId: 'session-id',
+      onToken: (_) {},
+      onDone: () {},
+      onError: (_) {},
+    );
+    while (transport.requests.isEmpty) {
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    expect(await gateway.cancelActiveMessage(), isTrue);
+    await sending;
+    expect(transport.cancelled, [transport.requests.single.requestId]);
+  });
+
+  test('cancels native SSE while response headers are pending', () async {
+    final transport = _FakeMtlsTransport()
+      ..autoComplete = false
+      ..delayedResponseHead = Completer<MtlsResponseHead>();
+    addTearDown(transport.dispose);
+    final api = ApiClient.fromConnection(
+      _connection(),
+      mtlsTransport: transport,
+    );
+    final gateway = GatewayChatClient(api);
+    addTearDown(gateway.abort);
+
+    final sending = gateway.sendMessageStreaming(
+      message: 'hello',
+      sessionId: 'session-id',
+      onToken: (_) {},
+      onDone: () {},
+      onError: (_) {},
+    );
+    while (transport.requests.isEmpty) {
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    expect(await gateway.cancelActiveMessage(), isTrue);
+    await sending;
+    expect(transport.cancelled, [transport.requests.single.requestId]);
+  });
+
+  test('missing alias fails requests closed', () async {
+    final client = GatewayHttpClientFactory.create(
+      _connection(alias: null),
+      mtlsTransport: _FakeMtlsTransport(),
+    );
+    addTearDown(client.close);
+
+    await expectLater(
+      client.get(Uri.parse('https://gateway.example.com/health')),
+      throwsStateError,
+    );
+  });
+}

--- a/test/mtls_connection_dialog_test.dart
+++ b/test/mtls_connection_dialog_test.dart
@@ -1,0 +1,236 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hermes_android/core/services/connection_manager.dart';
+import 'package:hermes_android/main.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MemoryCredentialStore implements CredentialStore {
+  final Map<String, String> values = {};
+  final Map<String, String> _cache = {};
+
+  @override
+  Future<void> delete(String key) async {
+    values.remove(key);
+    _cache.remove(key);
+  }
+
+  @override
+  Future<String?> read(String key) async {
+    final value = values[key];
+    if (value == null) {
+      _cache.remove(key);
+    } else {
+      _cache[key] = value;
+    }
+    return value;
+  }
+
+  @override
+  String? readCached(String key) => _cache[key];
+
+  @override
+  Future<void> write(String key, String value) async {
+    values[key] = value;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel('com.hermesagent.hermes_android/mtls');
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          switch (call.method) {
+            case 'chooseCertificate':
+            case 'describeCertificate':
+              return <String, Object?>{
+                'alias': 'android-client-cert',
+                'label': 'Hermes Client Certificate',
+              };
+          }
+          return null;
+        });
+  });
+
+  tearDown(() {
+    debugDefaultTargetPlatformOverride = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  testWidgets('mTLS requires explicit HTTPS but HTTP remains valid when off', (
+    tester,
+  ) async {
+    await _asAndroid(() async {
+      final prefs = await SharedPreferences.getInstance();
+      final manager = await ConnectionManager.create(
+        prefs,
+        credentialStore: _MemoryCredentialStore(),
+      );
+      await tester.pumpWidget(HermesApp(connManager: manager));
+
+      await tester.tap(find.byTooltip('Add Connection'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Host'),
+        'http://gateway.example.com',
+      );
+
+      await tester.tap(find.text('mTLS (optional)'));
+      await tester.pumpAndSettle();
+      expect(find.text('Hermes Client Certificate'), findsOneWidget);
+
+      await tester.tap(find.text('Connect'));
+      await tester.pump();
+      expect(
+        find.text('mTLS requires an explicit https:// Gateway host.'),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.text('mTLS (optional)'));
+      await tester.pump();
+      expect(
+        find.text('mTLS requires an explicit https:// Gateway host.'),
+        findsNothing,
+      );
+    });
+  });
+
+  testWidgets('edit connection restores remembered mTLS certificate', (
+    tester,
+  ) async {
+    await _asAndroid(() async {
+      final prefs = await SharedPreferences.getInstance();
+      final manager = await ConnectionManager.create(
+        prefs,
+        credentialStore: _MemoryCredentialStore(),
+      );
+      await manager.saveConnection(
+        'Secure gateway',
+        'https://gateway.example.com',
+        443,
+        'synthetic-api-key',
+        mtlsEnabled: true,
+        mtlsCertificateAlias: 'android-client-cert',
+      );
+      await tester.pumpWidget(HermesApp(connManager: manager));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Edit Connection'));
+      await tester.pumpAndSettle();
+
+      final switchTile = tester.widget<SwitchListTile>(
+        find.widgetWithText(SwitchListTile, 'mTLS (optional)'),
+      );
+      expect(switchTile.value, isTrue);
+      expect(find.text('Hermes Client Certificate'), findsOneWidget);
+    });
+  });
+
+  testWidgets('Gateway API keys require an HTTPS host', (tester) async {
+    final prefs = await SharedPreferences.getInstance();
+    final manager = await ConnectionManager.create(
+      prefs,
+      credentialStore: _MemoryCredentialStore(),
+    );
+    await tester.pumpWidget(HermesApp(connManager: manager));
+
+    await tester.tap(find.byTooltip('Add Connection'));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Host'),
+      'http://gateway.example.com',
+    );
+    await tester.enterText(
+      find.widgetWithText(TextField, 'API Key'),
+      'synthetic-api-key',
+    );
+    await tester.tap(find.text('Connect'));
+    await tester.pump();
+
+    expect(
+      find.text('Gateway API keys require an explicit https:// host.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('new connection does not preconfigure a Desktop Gateway', (
+    tester,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    final manager = await ConnectionManager.create(
+      prefs,
+      credentialStore: _MemoryCredentialStore(),
+    );
+    await tester.pumpWidget(HermesApp(connManager: manager));
+
+    await tester.tap(find.byTooltip('Add Connection'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Custom proxy and dashboard details'));
+    await tester.pumpAndSettle();
+
+    final field = tester.widget<TextField>(
+      find.widgetWithText(TextField, 'Desktop Gateway URL (optional)'),
+    );
+    expect(field.controller!.text, isEmpty);
+    final dashboardField = tester.widget<TextField>(
+      find.widgetWithText(TextField, 'Dashboard URL (optional)'),
+    );
+    expect(dashboardField.controller!.text, isEmpty);
+  });
+
+  testWidgets('Desktop Gateway requires an HTTPS URL', (tester) async {
+    await _asAndroid(() async {
+      final prefs = await SharedPreferences.getInstance();
+      final manager = await ConnectionManager.create(
+        prefs,
+        credentialStore: _MemoryCredentialStore(),
+      );
+      await tester.pumpWidget(HermesApp(connManager: manager));
+
+      await tester.tap(find.byTooltip('Add Connection'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Host'),
+        'https://gateway.example.com',
+      );
+      final advanced = find.text('Custom proxy and dashboard details');
+      await tester.ensureVisible(advanced);
+      await tester.tap(advanced);
+      await tester.pumpAndSettle();
+      final desktopField = find.widgetWithText(
+        TextField,
+        'Desktop Gateway URL (optional)',
+      );
+      await tester.ensureVisible(desktopField);
+      await tester.enterText(desktopField, 'http://desktop.example.com:42848');
+
+      final connect = find.text('Connect');
+      await tester.ensureVisible(connect);
+      await tester.tap(connect);
+      await tester.pump();
+
+      expect(
+        find.text(
+          'The Desktop Gateway URL must be a valid https:// URL because it carries session credentials.',
+        ),
+        findsOneWidget,
+      );
+    });
+  });
+}
+
+Future<void> _asAndroid(Future<void> Function() body) async {
+  debugDefaultTargetPlatformOverride = TargetPlatform.android;
+  try {
+    await body();
+  } finally {
+    debugDefaultTargetPlatformOverride = null;
+  }
+}

--- a/test/secure_connection_storage_test.dart
+++ b/test/secure_connection_storage_test.dart
@@ -82,6 +82,7 @@ void _expectNoPlaintextCredentials(SharedPreferences prefs) {
   for (final connection in metadata) {
     expect(connection, isNot(contains('api_key')));
     expect(connection, isNot(contains('dashboard_password')));
+    expect(connection, isNot(contains('mtls_certificate_alias')));
   }
 }
 
@@ -158,6 +159,33 @@ void main() {
     expect(reloaded.getConnections()[0].apiKey, 'synthetic-api-a');
     expect(store.writes, writesAfterMigration);
     _expectNoPlaintextCredentials(prefs);
+  });
+
+  test('removes the obsolete prefilled Desktop Gateway URL', () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      'saved_connections': <String>[
+        jsonEncode(<String, Object?>{
+          'id': 'profile-a',
+          'label': 'Gateway',
+          'host': 'gateway.example.com',
+          'port': 443,
+          'use_https': true,
+          'desktop_gateway_url': 'http://192.168.1.193/desktop',
+        }),
+      ],
+    });
+    final prefs = await SharedPreferences.getInstance();
+
+    final manager = await ConnectionManager.create(
+      prefs,
+      credentialStore: _FaultInjectingCredentialStore(),
+    );
+
+    expect(manager.getConnections().single.desktopGatewayUrl, isNull);
+    expect(
+      _storedMetadata(prefs).single,
+      isNot(contains('desktop_gateway_url')),
+    );
   });
 
   test('partial read-back failure retains all legacy plaintext and retry is '
@@ -290,5 +318,91 @@ void main() {
     expect(retained.apiKey, 'synthetic-api-stable');
     expect(retained.dashboardPassword, 'synthetic-password-stable');
     _expectNoPlaintextCredentials(prefs);
+  });
+
+  test(
+    'remembers mTLS selection securely and clears it when disabled',
+    () async {
+      final prefs = await SharedPreferences.getInstance();
+      final store = _FaultInjectingCredentialStore();
+      final manager = await ConnectionManager.create(
+        prefs,
+        credentialStore: store,
+      );
+
+      await manager.saveConnection(
+        'Secure gateway',
+        'https://gateway.example.com',
+        8642,
+        'synthetic-api-key',
+        mtlsEnabled: true,
+        mtlsCertificateAlias: 'android-client-cert',
+      );
+
+      var connection = manager.getConnections().single;
+      expect(connection.useHttps, isTrue);
+      expect(connection.mtlsEnabled, isTrue);
+      expect(connection.mtlsCertificateAlias, 'android-client-cert');
+      final metadata = _storedMetadata(prefs).single;
+      expect(metadata['mtls_enabled'], isTrue);
+      expect(metadata, isNot(contains('mtls_certificate_alias')));
+      expect(store.values.values.single, contains('android-client-cert'));
+
+      final reloaded = await ConnectionManager.create(
+        prefs,
+        credentialStore: store,
+      );
+      connection = reloaded.getConnections().single;
+      expect(connection.mtlsEnabled, isTrue);
+      expect(connection.mtlsCertificateAlias, 'android-client-cert');
+
+      await reloaded.updateConnection(
+        connection.id,
+        connection.label,
+        'http://gateway.example.com',
+        8642,
+        connection.apiKey,
+        mtlsEnabled: false,
+      );
+      connection = reloaded.getConnections().single;
+      expect(connection.useHttps, isFalse);
+      expect(connection.mtlsEnabled, isFalse);
+      expect(connection.mtlsCertificateAlias, isNull);
+      expect(
+        store.values.values.single,
+        isNot(contains('android-client-cert')),
+      );
+      _expectNoPlaintextCredentials(prefs);
+    },
+  );
+
+  test('rejects enabled mTLS without a certificate alias', () async {
+    final prefs = await SharedPreferences.getInstance();
+    final manager = await ConnectionManager.create(
+      prefs,
+      credentialStore: _FaultInjectingCredentialStore(),
+    );
+
+    await expectLater(
+      manager.saveConnection(
+        'Invalid',
+        'https://gateway.example.com',
+        8642,
+        'synthetic-api-key',
+        mtlsEnabled: true,
+      ),
+      throwsArgumentError,
+    );
+    await expectLater(
+      manager.saveConnection(
+        'Invalid',
+        'http://gateway.example.com',
+        8642,
+        'synthetic-api-key',
+        mtlsEnabled: true,
+        mtlsCertificateAlias: 'android-client-cert',
+      ),
+      throwsArgumentError,
+    );
   });
 }


### PR DESCRIPTION
## Summary

- add optional per-connection mTLS configuration to the Add/Edit Connection flow
- use Android's certificate picker and remember the selected KeyChain alias in encrypted storage
- route Gateway REST/SSE, dashboard REST, and Desktop Gateway WebSocket traffic through a native OkHttp client when mTLS is enabled
- support a separate dashboard URL and port while reusing the selected client certificate

## Fixes included

- wait for the Flutter event stream before starting native requests, preventing successful responses from arriving with an empty body
- remove and migrate the obsolete preconfigured Desktop Gateway URL
- compose separate dashboard URLs and ports correctly
- choose the dashboard SPA token for open deployments and one-use tickets for authenticated/proxied deployments
- deduplicate concurrent Desktop Gateway connection attempts and prevent closed clients from being resurrected by stalled requests

## Security

- private keys and certificate material remain inside Android KeyChain; Dart receives only the certificate alias and display label
- API keys, dashboard passwords, and certificate aliases are persisted through secure storage rather than SharedPreferences
- native TLS retains system CA trust and hostname verification with no insecure fallback
- authenticated Gateway and dashboard requests, plus all Desktop Gateway sockets, fail closed on cleartext HTTP/WebSocket URLs
- unauthenticated local HTTP endpoints remain supported

## Validation

- full Flutter test suite: 328 tests passed
- `flutter analyze --no-pub`
- release Kotlin compilation
- final sensitive-data and correctness reviews found no high-confidence issues