### PR TITLE
fix: resync legacy turn history after Android resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ Android client for [Hermes Agent](https://hermes-agent.nousresearch.com/) — ch
   Hermes Desktop tray notification behaviour. Notifications are
   automatically cleared when returning to the app.
 
+### Gateway transport compatibility
+
+Stock Hermes Agent releases do not currently advertise the experimental
+`capabilities.turn_recovery` contract in `gateway.ready`. Against those releases,
+the app intentionally uses the legacy Desktop Gateway transport and displays
+**Background recovery unavailable — legacy transport**. If a legacy turn finishes
+while Android is backgrounded, the app re-syncs that session's server-side
+history on resume. The durable exactly-once recovery path activates only when a
+gateway explicitly advertises the compatible recovery contract.
+
 See [CHANGELOG.md](CHANGELOG.md) for the complete `.13` change list and
 [docs/HERMESAPK_DEVELOPMENT_LOG.md](docs/HERMESAPK_DEVELOPMENT_LOG.md) for the
 sanitized implementation and validation record.

--- a/lib/core/screens/chat_screen.dart
+++ b/lib/core/screens/chat_screen.dart
@@ -196,6 +196,8 @@ class _ChatScreenState extends State<ChatScreen> with WidgetsBindingObserver {
   String? _activeClientTurnId;
   bool _recoveringTurn = false;
   bool _legacyTransportFallback = false;
+  bool _legacyHistoryResyncPending = false;
+  bool _legacyHistoryResyncing = false;
   int _responseGeneration = 0;
   bool _approvalDialogOpen = false;
   final List<_PendingSensitivePrompt> _sensitivePromptQueue = [];
@@ -352,11 +354,16 @@ class _ChatScreenState extends State<ChatScreen> with WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.paused) {
       _appInBackground = true;
+      if (_legacyTransportFallback && (_sending || _streaming)) {
+        _legacyHistoryResyncPending = true;
+      }
     } else if (state == AppLifecycleState.resumed) {
       _appInBackground = false;
       unawaited(_turnNotifications.cancelAll());
       if (_desktopGateway != null) unawaited(_ensureDesktopSession());
-      if (_turnApplicationSession != null && !_legacyTransportFallback) {
+      if (_legacyTransportFallback) {
+        unawaited(_resyncLegacyHistoryAfterResume());
+      } else if (_turnApplicationSession != null) {
         unawaited(_recoverPendingTurn());
       }
     }
@@ -681,6 +688,36 @@ class _ChatScreenState extends State<ChatScreen> with WidgetsBindingObserver {
         _error = errStr;
         _loading = false;
       });
+    }
+  }
+
+  Future<void> _resyncLegacyHistoryAfterResume() async {
+    if (!mounted ||
+        !_legacyTransportFallback ||
+        !_legacyHistoryResyncPending ||
+        _appInBackground ||
+        _legacyHistoryResyncing ||
+        _loading ||
+        _sending ||
+        _streaming) {
+      return;
+    }
+
+    _legacyHistoryResyncing = true;
+    try {
+      final messages = await _client.getMessages(widget.session.id);
+      if (!mounted || _appInBackground) return;
+      _extractToolMessages(messages);
+      setState(() {
+        _messages = messages;
+        _legacyHistoryResyncPending = false;
+      });
+      _scheduleInitialEndAlignment();
+    } catch (_) {
+      // Keep the pending watermark so the next resume can retry. The composer
+      // remains usable and the normal screen reload path still fetches history.
+    } finally {
+      _legacyHistoryResyncing = false;
     }
   }
 
@@ -1700,6 +1737,7 @@ class _ChatScreenState extends State<ChatScreen> with WidgetsBindingObserver {
         _gatewayTurnStatus = null;
         _activeResponseTransport = _ResponseTransport.none;
       });
+      unawaited(_resyncLegacyHistoryAfterResume());
       _scheduleScrollTarget(_scrollCoordinator.endStreaming());
       if (_awaitingVoiceReply) {
         _awaitingVoiceReply = false;
@@ -1730,6 +1768,7 @@ class _ChatScreenState extends State<ChatScreen> with WidgetsBindingObserver {
         });
       }
       _handleSendError(error);
+      unawaited(_resyncLegacyHistoryAfterResume());
     }
   }
 

--- a/test/chat_turn_recovery_test.dart
+++ b/test/chat_turn_recovery_test.dart
@@ -198,6 +198,70 @@ void main() {
   );
 
   testWidgets(
+    'legacy fallback resyncs a backgrounded turn once the stream disconnects',
+    (tester) async {
+      final session = _FakeTurnSession(
+        const <Object>[],
+        recoverError: const GatewayTurnCoordinatorException(
+          GatewayTurnCoordinatorFailure.unsupportedCapability,
+        ),
+      );
+      final submission = Completer<void>();
+      final history = _ResyncChatHttpClient();
+      final apiClient = ApiClient(
+        baseUrl: 'http://recovery.fixture',
+        apiKey: 'fixture-key',
+        httpClient: history,
+      );
+      await _pumpChat(
+        tester,
+        turnSession: session,
+        apiClient: apiClient,
+        testRemotePromptSubmit:
+            ({required sessionId, required text, required onEvent}) {
+              return submission.future;
+            },
+      );
+
+      expect(history.messageRequestCount, 1);
+      await tester.enterText(find.byType(TextField), 'Finish in background');
+      await tester.tap(find.byTooltip('Send'));
+      await tester.pump();
+
+      for (final state in const <AppLifecycleState>[
+        AppLifecycleState.inactive,
+        AppLifecycleState.hidden,
+        AppLifecycleState.paused,
+        AppLifecycleState.hidden,
+        AppLifecycleState.inactive,
+        AppLifecycleState.resumed,
+      ]) {
+        tester.binding.handleAppLifecycleStateChanged(state);
+      }
+      history.includeCompletedTurn = true;
+      submission.completeError(StateError('socket closed'));
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Server-side final response'), findsOneWidget);
+      expect(history.messageRequestCount, 2);
+
+      for (final state in const <AppLifecycleState>[
+        AppLifecycleState.inactive,
+        AppLifecycleState.hidden,
+        AppLifecycleState.paused,
+        AppLifecycleState.hidden,
+        AppLifecycleState.inactive,
+        AppLifecycleState.resumed,
+      ]) {
+        tester.binding.handleAppLifecycleStateChanged(state);
+      }
+      await tester.pumpAndSettle();
+      expect(history.messageRequestCount, 2);
+    },
+  );
+
+  testWidgets(
     'network auth malformed and unsafe journal errors never enable legacy',
     (tester) async {
       final errors = <Object>[
@@ -305,12 +369,13 @@ void main() {
 Future<void> _pumpChat(
   WidgetTester tester, {
   required _FakeTurnSession turnSession,
+  ApiClient? apiClient,
   TestRemotePromptSubmit? testRemotePromptSubmit,
   TestRemoteAttachmentUpload? testRemoteAttachmentUpload,
   AttachmentDraftService? attachmentDraftService,
   List<AttachmentDraft> initialDrafts = const [],
 }) async {
-  final apiClient = ApiClient(
+  apiClient ??= ApiClient(
     baseUrl: 'http://recovery.fixture',
     apiKey: 'synthetic-key',
     httpClient: _EmptyChatHttpClient(),
@@ -496,6 +561,34 @@ class _EmptyChatHttpClient extends http.BaseClient {
     if (request.method == 'GET' && request.url.path.endsWith('/messages')) {
       return http.StreamedResponse(
         Stream.value(utf8.encode(jsonEncode({'data': <Object>[]}))),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+    return http.StreamedResponse(
+      Stream.value(utf8.encode(jsonEncode({'error': 'unexpected request'}))),
+      404,
+      headers: {'content-type': 'application/json'},
+    );
+  }
+}
+
+class _ResyncChatHttpClient extends http.BaseClient {
+  int messageRequestCount = 0;
+  bool includeCompletedTurn = false;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    if (request.method == 'GET' && request.url.path.endsWith('/messages')) {
+      messageRequestCount += 1;
+      final messages = includeCompletedTurn
+          ? <Map<String, dynamic>>[
+              {'role': 'user', 'content': 'Finish in background'},
+              {'role': 'assistant', 'content': 'Server-side final response'},
+            ]
+          : <Map<String, dynamic>>[];
+      return http.StreamedResponse(
+        Stream.value(utf8.encode(jsonEncode({'data': messages}))),
         200,
         headers: {'content-type': 'application/json'},
       );


### PR DESCRIPTION
## Summary

Addresses the actionable client-side part of #84.

Stock Hermes does not advertise the experimental `capabilities.turn_recovery` contract, so the app correctly falls back to the legacy Desktop Gateway transport. Previously, a legacy turn that completed while Android was paused could lose its final client-side message until the user left and reopened the chat.

## Changes

- Mark a legacy history re-sync as pending only when Android pauses during an active turn.
- Re-fetch authoritative server history after resume once the legacy stream settles or disconnects.
- Keep the re-sync pending after a transient fetch failure, without blocking the composer.
- Avoid fetching on every ordinary pause/resume cycle when no turn was active.
- Document why stock Hermes shows the legacy transport banner and when durable recovery can activate.

## Verification

- `flutter test --no-pub` -> 298 passed
- `flutter analyze --no-pub` -> no issues
- Added a lifecycle regression test covering a server-side final response after a background socket failure.

## Scope

This does not pretend that stock Hermes supports the unshipped `turn_recovery` contract. It fixes the real fallback path and documents the server capability dependency.