### PR TITLE
fix: show actual gateway validation status and endpoint

### DIFF
--- a/lib/core/services/connection_manager.dart
+++ b/lib/core/services/connection_manager.dart
@@ -489,6 +489,44 @@ class ConnectionManager {
   }
 }
 
+class ApiHealthCheckResult {
+  final bool isHealthy;
+  final Uri endpoint;
+  final int? statusCode;
+
+  const ApiHealthCheckResult._({
+    required this.isHealthy,
+    required this.endpoint,
+    this.statusCode,
+  });
+
+  const ApiHealthCheckResult.success(Uri endpoint)
+    : this._(isHealthy: true, endpoint: endpoint);
+
+  const ApiHealthCheckResult.httpFailure(Uri endpoint, int statusCode)
+    : this._(isHealthy: false, endpoint: endpoint, statusCode: statusCode);
+
+  const ApiHealthCheckResult.networkFailure(Uri endpoint)
+    : this._(isHealthy: false, endpoint: endpoint);
+
+  String userMessage({required bool apiKeyProvided}) {
+    if (isHealthy) return '';
+    if (statusCode == 401 || statusCode == 403) {
+      return apiKeyProvided
+          ? 'API key was rejected by $endpoint (HTTP $statusCode).'
+          : 'Server requires an API key. Enter your API_SERVER_KEY.';
+    }
+    if (statusCode == 404) {
+      return 'Gateway endpoint $endpoint returned HTTP 404. Check the Gateway '
+          'path prefix and reverse-proxy routes.';
+    }
+    if (statusCode case final code?) {
+      return 'Gateway endpoint $endpoint returned HTTP $code.';
+    }
+    return 'Cannot reach Gateway endpoint $endpoint.';
+  }
+}
+
 /// HTTP client for the Hermes Gateway API Server (port 8642).
 ///
 /// Uses Bearer token auth. Same pattern as hermes-desktop.
@@ -579,25 +617,41 @@ class ApiClient {
 
   // ── Health check ─────────────────────────────────────────────────────
 
-  Future<bool> healthCheck() async {
+  Future<ApiHealthCheckResult> checkHealth() async {
+    final healthEndpoint = Uri.parse('$baseUrl/health');
+    var activeEndpoint = healthEndpoint;
     try {
       final health = await _http
-          .get(Uri.parse('$baseUrl/health'), headers: _headers)
+          .get(healthEndpoint, headers: _headers)
           .timeout(const Duration(seconds: 5));
-      if (health.statusCode == 401 || health.statusCode == 403) return false;
-      if (health.statusCode != 200) return false;
+      if (health.statusCode != 200) {
+        return ApiHealthCheckResult.httpFailure(
+          healthEndpoint,
+          health.statusCode,
+        );
+      }
 
       // /health may be intentionally public on some deployments. Confirm that
       // the saved API key can also reach an authenticated endpoint before the
       // add/update connection dialogs accept it as valid.
+      final sessionsEndpoint = Uri.parse('$baseUrl/api/sessions');
+      activeEndpoint = sessionsEndpoint;
       final sessions = await _http
-          .get(Uri.parse('$baseUrl/api/sessions'), headers: _headers)
+          .get(sessionsEndpoint, headers: _headers)
           .timeout(const Duration(seconds: 5));
-      return sessions.statusCode == 200;
+      if (sessions.statusCode != 200) {
+        return ApiHealthCheckResult.httpFailure(
+          sessionsEndpoint,
+          sessions.statusCode,
+        );
+      }
+      return ApiHealthCheckResult.success(sessionsEndpoint);
     } catch (_) {
-      return false;
+      return ApiHealthCheckResult.networkFailure(activeEndpoint);
     }
   }
+
+  Future<bool> healthCheck() async => (await checkHealth()).isHealthy;
 
   // ── Generic HTTP helpers (for Dashboard API compatibility) ────────────
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -166,7 +166,8 @@ class HermesHeader extends StatelessWidget {
         children: [
           Text(
             'HERMES',
-            style: TextStyle(fontFamily: 'Cinzel', 
+            style: TextStyle(
+              fontFamily: 'Cinzel',
               fontSize: 28,
               fontWeight: FontWeight.w700,
               color: const Color(0xFFD4AF37),
@@ -405,18 +406,18 @@ class _HomeScreenState extends State<HomeScreen> {
                           apiKey: key,
                           pathPrefix: conn.gatewayPrefix ?? '',
                         );
-                        final ok = await client.healthCheck();
+                        final result = await client.checkHealth();
                         client.close();
 
                         if (!ctx.mounted) return;
 
-                        if (ok) {
+                        if (result.isHealthy) {
                           await widget.connManager.updateApiKey(conn.id, key);
                           if (!ctx.mounted) return;
                           await _closeDialogAndRefresh(ctx);
                         } else {
                           setDialogState(() {
-                            error = 'Invalid API key. Server returned 401.';
+                            error = result.userMessage(apiKeyProvided: true);
                             validating = false;
                           });
                         }
@@ -613,14 +614,14 @@ class _HomeScreenState extends State<HomeScreen> {
                           apiKey: conn.apiKey,
                           pathPrefix: gatewayPrefix,
                         );
-                        final ok = await apiClient.healthCheck();
+                        final result = await apiClient.checkHealth();
                         apiClient.close();
                         if (!ctx.mounted) return;
-                        if (!ok) {
+                        if (!result.isHealthy) {
                           setDialogState(() {
-                            error =
-                                'Could not reach/authenticate the Gateway API at '
-                                '${conn.host}:${conn.port}$gatewayPrefix.';
+                            error = result.userMessage(
+                              apiKeyProvided: conn.apiKey.isNotEmpty,
+                            );
                             validating = false;
                           });
                           return;
@@ -753,7 +754,8 @@ class _HomeScreenState extends State<HomeScreen> {
       appBar: AppBar(
         title: Text(
           'HERMES',
-          style: TextStyle(fontFamily: 'Cinzel', 
+          style: TextStyle(
+            fontFamily: 'Cinzel',
             fontWeight: FontWeight.w700,
             letterSpacing: 6,
             fontSize: 22,
@@ -919,16 +921,14 @@ class _AddDialogState extends State<_AddDialog> {
         apiKey: apiKey,
         pathPrefix: gatewayPrefix,
       );
-      final ok = await client.healthCheck();
+      final result = await client.checkHealth();
       client.close();
 
       if (!mounted) return;
 
-      if (!ok) {
+      if (!result.isHealthy) {
         setState(() {
-          _error = apiKey.isEmpty
-              ? 'Server requires an API key. Enter your API_SERVER_KEY.'
-              : 'Invalid API key. Server returned 401.';
+          _error = result.userMessage(apiKeyProvided: apiKey.isNotEmpty);
           _validating = false;
         });
         return;

--- a/test/connection_manager_test.dart
+++ b/test/connection_manager_test.dart
@@ -441,6 +441,57 @@ void main() {
       client.close();
     });
 
+    test(
+      'checkHealth reports the failing prefixed endpoint and status',
+      () async {
+        final client = ApiClient(
+          baseUrl: 'https://hermes.example',
+          pathPrefix: '/hermes',
+          apiKey: 'prefixed-test-key',
+          httpClient: MockClient((request) async {
+            expect(request.url.path, '/hermes/health');
+            return http.Response('not found', 404);
+          }),
+        );
+
+        final result = await client.checkHealth();
+
+        expect(result.isHealthy, isFalse);
+        expect(result.statusCode, 404);
+        expect(result.endpoint.path, '/hermes/health');
+        expect(
+          result.userMessage(apiKeyProvided: true),
+          allOf(contains('HTTP 404'), contains('reverse-proxy routes')),
+        );
+        client.close();
+      },
+    );
+
+    test(
+      'checkHealth attributes auth failures to the sessions endpoint',
+      () async {
+        final client = ApiClient(
+          baseUrl: 'http://hermes.local:8642',
+          apiKey: 'invalid-test-key',
+          httpClient: MockClient((request) async {
+            if (request.url.path == '/health') return http.Response('{}', 200);
+            return http.Response('unauthorized', 401);
+          }),
+        );
+
+        final result = await client.checkHealth();
+
+        expect(result.isHealthy, isFalse);
+        expect(result.statusCode, 401);
+        expect(result.endpoint.path, '/api/sessions');
+        expect(
+          result.userMessage(apiKeyProvided: true),
+          contains('API key was rejected'),
+        );
+        client.close();
+      },
+    );
+
     test('deleteSession deletes a remote Hermes session', () async {
       final client = ApiClient(
         baseUrl: 'http://hermes.local:8642',


### PR DESCRIPTION
## Summary

Fixes #85.

Connection validation reduced every non-200 response to `Invalid API key. Server returned 401`, even when the proxy actually returned 404 or the endpoint was unreachable. This hid reverse-proxy path errors such as a missing `/hermes/health` route.

## Changes

- Return a structured health-check result with the exact failing endpoint and HTTP status.
- Show authentication wording only for real HTTP 401/403 responses.
- Give HTTP 404 responses an actionable Gateway path-prefix/reverse-proxy message.
- Preserve the existing boolean `healthCheck()` API for non-dialog call sites.
- Add regression tests for a prefixed `/health` 404 and an authenticated `/api/sessions` 401.

## Verification

- `flutter test --no-pub` -> 299 passed
- `flutter analyze --no-pub` -> no issues