### PR TITLE
fix(clarify): parse batch questions[] payload from stock Hermes gateways

### DIFF
--- a/lib/core/models/gateway_clarify.dart
+++ b/lib/core/models/gateway_clarify.dart
@@ -1,6 +1,20 @@
 /// A request-ID keyed clarification prompt emitted by Hermes.
+///
+/// Stock Hermes gateways emit clarification prompts in two wire shapes:
+///
+/// * Flat (single question, legacy):
+///   `{"request_id": ..., "question": ..., "choices": [...], "multi_select": ...}`
+/// * Batch (current Hermes agent builds, even for a single question):
+///   `{"request_id": ..., "questions": [{"qid": ..., "question": ..., "choices": [...], "multi_select": ...}]}`
+///
+/// Batch responses must echo the per-question `qid` back as `question_id` so
+/// the gateway can lock each answer independently.
 class GatewayClarifyRequest {
   final String requestId;
+
+  /// The per-question id inside a batch `questions[]` payload. Null for the
+  /// flat single-question shape.
+  final String? questionId;
   final String question;
   final List<String> choices;
   final bool multiSelect;
@@ -10,28 +24,58 @@ class GatewayClarifyRequest {
     required this.question,
     required this.choices,
     required this.multiSelect,
+    this.questionId,
   });
 
   bool get hasChoices => choices.isNotEmpty;
 
+  /// Parses a `clarify.request` event payload into zero or more prompts.
+  ///
+  /// Batch payloads expand to one prompt per question (each carrying its own
+  /// `questionId`); flat payloads expand to a single prompt with no
+  /// `questionId`. Questions missing a usable `qid` in a batch are dropped,
+  /// since the gateway cannot correlate an answer without one.
+  static List<GatewayClarifyRequest> fromEventDataList(
+    Map<String, dynamic> data,
+  ) {
+    final requestId = data['request_id']?.toString().trim() ?? '';
+    if (requestId.isEmpty) return const [];
+
+    final rawQuestions = data['questions'];
+    if (rawQuestions is List) {
+      final requests = <GatewayClarifyRequest>[];
+      for (final rawQuestion in rawQuestions) {
+        if (rawQuestion is! Map) continue;
+        final qid = rawQuestion['qid']?.toString().trim() ?? '';
+        if (qid.isEmpty) continue;
+        final choices = _normalizeChoices(rawQuestion['choices']);
+        requests.add(
+          GatewayClarifyRequest(
+            requestId: requestId,
+            questionId: qid,
+            question: _normalizeQuestion(
+              rawQuestion['question']?.toString(),
+            ),
+            choices: choices,
+            multiSelect:
+                rawQuestion['multi_select'] == true && choices.isNotEmpty,
+          ),
+        );
+      }
+      return requests;
+    }
+
+    final flat = fromEventData(data);
+    return flat == null ? const [] : [flat];
+  }
+
+  /// Parses the legacy flat single-question payload.
   static GatewayClarifyRequest? fromEventData(Map<String, dynamic> data) {
     final requestId = data['request_id']?.toString().trim() ?? '';
     if (requestId.isEmpty) return null;
 
-    final rawChoices = data['choices'];
-    final choices = rawChoices is List
-        ? rawChoices
-              .whereType<String>()
-              .where(
-                (choice) =>
-                    choice.trim().isNotEmpty &&
-                    choice.length <= 200 &&
-                    !choice.contains('\n') &&
-                    !choice.contains('\r'),
-              )
-              .toList(growable: false)
-        : const <String>[];
-    final question = data['question']?.toString().trim() ?? '';
+    final choices = _normalizeChoices(data['choices']);
+    final question = _normalizeQuestion(data['question']?.toString());
 
     return GatewayClarifyRequest(
       requestId: requestId,
@@ -42,4 +86,27 @@ class GatewayClarifyRequest {
       multiSelect: data['multi_select'] == true && choices.isNotEmpty,
     );
   }
+
+  static List<String> _normalizeChoices(Object? rawChoices) {
+    if (rawChoices is! List) return const <String>[];
+    return rawChoices
+        .whereType<String>()
+        .where(
+          (choice) =>
+              choice.trim().isNotEmpty &&
+              choice.length <= 200 &&
+              !choice.contains('\n') &&
+              !choice.contains('\r'),
+        )
+        .toList(growable: false);
+  }
+
+  static String _normalizeQuestion(String? rawQuestion) =>
+      rawQuestion?.trim() ?? '';
+
+  /// Identity key for queue de-duplication: two prompts are the same prompt
+  /// only when both the gateway request id and the per-question id agree.
+  String get identityKey => questionId == null
+      ? requestId
+      : '$requestId::$questionId';
 }

--- a/lib/core/screens/chat_screen.dart
+++ b/lib/core/screens/chat_screen.dart
@@ -2384,16 +2384,17 @@ class _ChatScreenState extends State<ChatScreen> with WidgetsBindingObserver {
     Map<String, dynamic> eventData,
     int responseGeneration,
   ) {
-    final request = GatewayClarifyRequest.fromEventData(eventData);
-    if (request == null) return;
-    final duplicate =
-        _activeClarifyPrompt?.request.requestId == request.requestId ||
-        _clarifyPromptQueue.any(
-          (pending) => pending.request.requestId == request.requestId,
-        );
-    if (duplicate) return;
-
-    _clarifyPromptQueue.add(_PendingClarifyPrompt(request, responseGeneration));
+    final requests = GatewayClarifyRequest.fromEventDataList(eventData);
+    if (requests.isEmpty) return;
+    for (final request in requests) {
+      final duplicate =
+          _activeClarifyPrompt?.request.identityKey == request.identityKey ||
+          _clarifyPromptQueue.any(
+            (pending) => pending.request.identityKey == request.identityKey,
+          );
+      if (duplicate) continue;
+      _clarifyPromptQueue.add(_PendingClarifyPrompt(request, responseGeneration));
+    }
     _drainClarifyPromptQueue();
   }
 
@@ -2411,8 +2412,8 @@ class _ChatScreenState extends State<ChatScreen> with WidgetsBindingObserver {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (!mounted ||
           pending.responseGeneration != _responseGeneration ||
-          _activeClarifyPrompt?.request.requestId !=
-              pending.request.requestId) {
+          _activeClarifyPrompt?.request.identityKey !=
+              pending.request.identityKey) {
         _activeClarifyPrompt = null;
         _drainSensitivePromptQueue();
         _drainClarifyPromptQueue();
@@ -2433,23 +2434,26 @@ class _ChatScreenState extends State<ChatScreen> with WidgetsBindingObserver {
           request: pending.request,
           onRespond: (answer) => desktopGateway.respondToClarify(
             requestId: pending.request.requestId,
+            questionId: pending.request.questionId,
             answer: answer,
           ),
         ),
       );
-      if (_activeClarifyPrompt?.request.requestId ==
-          pending.request.requestId) {
+      if (_activeClarifyPrompt?.request.identityKey ==
+          pending.request.identityKey) {
         _activeClarifyPrompt = null;
       }
 
       // System Back or a barrier dismiss maps to the official empty answer,
-      // matching Hermes Desktop's Skip behavior.
+      // matching Hermes Desktop's Skip behavior. Batch questions skip
+      // per-question so the remaining questions can still be answered.
       if (responded != true &&
           mounted &&
           pending.responseGeneration == _responseGeneration) {
         try {
           await desktopGateway.respondToClarify(
             requestId: pending.request.requestId,
+            questionId: pending.request.questionId,
             answer: '',
           );
         } catch (_) {

--- a/lib/core/services/desktop_gateway_client.dart
+++ b/lib/core/services/desktop_gateway_client.dart
@@ -391,9 +391,14 @@ class DesktopGatewayClient {
   Future<void> respondToClarify({
     required String requestId,
     required String answer,
+    String? questionId,
   }) async {
     final client = _connectedClient();
-    await client.respondToClarify(requestId: requestId, answer: answer);
+    await client.respondToClarify(
+      requestId: requestId,
+      answer: answer,
+      questionId: questionId,
+    );
   }
 
   WsClient _connectedClient() {

--- a/lib/core/services/ws_client.dart
+++ b/lib/core/services/ws_client.dart
@@ -749,6 +749,7 @@ class WsClient {
   Future<void> respondToClarify({
     required String requestId,
     required String answer,
+    String? questionId,
   }) async {
     if (requestId.trim().isEmpty) {
       throw ArgumentError.value(
@@ -757,10 +758,14 @@ class WsClient {
         'A Hermes request ID is required',
       );
     }
-    final response = await send('clarify.respond', {
+    final params = <String, dynamic>{
       'request_id': requestId,
       'answer': answer,
-    });
+    };
+    if (questionId != null && questionId.trim().isNotEmpty) {
+      params['question_id'] = questionId;
+    }
+    final response = await send('clarify.respond', params);
     final error = response['error'];
     if (error != null) {
       throw _gatewayResponseError(

--- a/test/connection_manager_test.dart
+++ b/test/connection_manager_test.dart
@@ -2285,6 +2285,48 @@ void main() {
       }
     });
 
+    test('echoes question_id back for batch clarify answers', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final requestSeen = Completer<Map<String, dynamic>>();
+      final socketSubscription = server
+          .transform(WebSocketTransformer())
+          .listen((socket) {
+            socket.listen((raw) {
+              final request = jsonDecode(raw as String) as Map<String, dynamic>;
+              if (!requestSeen.isCompleted) requestSeen.complete(request);
+              socket.add(
+                jsonEncode({
+                  'jsonrpc': '2.0',
+                  'id': request['id'],
+                  'result': {'status': 'ok', 'remaining': <String>[]},
+                }),
+              );
+            });
+          });
+      final client = WsClient('http://127.0.0.1:${server.port}');
+
+      try {
+        await client.connect();
+        await client.respondToClarify(
+          requestId: 'clarify-request-123',
+          questionId: 'q1',
+          answer: 'Balanced',
+        );
+        final request = await requestSeen.future;
+
+        expect(request['method'], 'clarify.respond');
+        expect(request['params'], {
+          'request_id': 'clarify-request-123',
+          'question_id': 'q1',
+          'answer': 'Balanced',
+        });
+      } finally {
+        client.close();
+        await socketSubscription.cancel();
+        await server.close(force: true);
+      }
+    });
+
     test('rejects an invalid approval choice before sending it', () async {
       final client = WsClient('http://127.0.0.1:1');
 

--- a/test/gateway_clarify_test.dart
+++ b/test/gateway_clarify_test.dart
@@ -54,6 +54,100 @@ void main() {
         isNull,
       );
     });
+
+    test('expands a batch questions[] payload into per-question prompts', () {
+      final requests = GatewayClarifyRequest.fromEventDataList({
+        'request_id': 'clarify-batch-1',
+        'questions': [
+          {
+            'qid': 'q1',
+            'question': 'Which interface?',
+            'choices': ['Compact', 'Detailed'],
+            'multi_select': false,
+          },
+          {
+            'qid': 'q2',
+            'question': 'Which features matter?',
+            'choices': ['Voice', 'Notifications'],
+            'multi_select': true,
+          },
+        ],
+      });
+
+      expect(requests, hasLength(2));
+      expect(requests[0].requestId, 'clarify-batch-1');
+      expect(requests[0].questionId, 'q1');
+      expect(requests[0].question, 'Which interface?');
+      expect(requests[0].choices, ['Compact', 'Detailed']);
+      expect(requests[0].multiSelect, isFalse);
+      expect(requests[0].identityKey, 'clarify-batch-1::q1');
+      expect(requests[1].questionId, 'q2');
+      expect(requests[1].multiSelect, isTrue);
+      expect(requests[1].identityKey, 'clarify-batch-1::q2');
+    });
+
+    test('maps a single-question batch onto the legacy prompt shape', () {
+      final requests = GatewayClarifyRequest.fromEventDataList({
+        'request_id': 'clarify-batch-1',
+        'questions': [
+          {
+            'qid': 'q1',
+            'question': 'Which product?',
+            'choices': ['A', 'B', 'C'],
+            'multi_select': false,
+          },
+        ],
+      });
+
+      expect(requests, hasLength(1));
+      expect(requests.single.questionId, 'q1');
+      expect(requests.single.question, 'Which product?');
+      expect(requests.single.choices, ['A', 'B', 'C']);
+    });
+
+    test('falls back to the flat payload when questions is absent', () {
+      final requests = GatewayClarifyRequest.fromEventDataList({
+        'request_id': 'clarify-flat-1',
+        'question': 'Which interface?',
+        'choices': ['Compact', 'Detailed'],
+      });
+
+      expect(requests, hasLength(1));
+      expect(requests.single.questionId, isNull);
+      expect(requests.single.identityKey, 'clarify-flat-1');
+      expect(requests.single.question, 'Which interface?');
+    });
+
+    test('drops batch questions without a usable qid', () {
+      final requests = GatewayClarifyRequest.fromEventDataList({
+        'request_id': 'clarify-batch-2',
+        'questions': [
+          {
+            'qid': '  ',
+            'question': 'Unanswerable',
+            'choices': ['X'],
+          },
+          {
+            'qid': 'q2',
+            'question': 'Answerable',
+            'choices': ['Y'],
+          },
+        ],
+      });
+
+      expect(requests, hasLength(1));
+      expect(requests.single.questionId, 'q2');
+    });
+
+    test('returns nothing for an empty questions list', () {
+      expect(
+        GatewayClarifyRequest.fromEventDataList({
+          'request_id': 'clarify-batch-3',
+          'questions': <Object>[],
+        }),
+        isEmpty,
+      );
+    });
   });
 
   group('GatewayClarifyDialog', () {

--- a/tools/fake_gateway/fake_gateway.py
+++ b/tools/fake_gateway/fake_gateway.py
@@ -608,6 +608,9 @@ async def handle_rpc(
         str, tuple[str, str, asyncio.Future[str]]
     ],
     pending_clarifications: dict[str, tuple[str, asyncio.Future[str]]],
+    pending_batch_clarifications: dict[
+        str, tuple[str, list[str], dict[str, str], asyncio.Future[str]]
+    ],
 ) -> None:
     request_id = payload.get("id")
     method = payload.get("method")
@@ -1044,6 +1047,60 @@ async def handle_rpc(
                     )
                     choice = await approval_future
                     response_text = f"Synthetic command resolved with {choice}."
+                elif "batch clarify" in text.lower() and "test" in text.lower():
+                    # Mirrors stock Hermes: the clarify tool emits a batch
+                    # `questions[]` payload even for a single prompt.
+                    clarify_request_id = state.next_prompt_id("clarify")
+                    clarify_future = asyncio.get_running_loop().create_future()
+                    qids = ["q1", "q2"]
+                    pending_batch_clarifications[clarify_request_id] = (
+                        session_id,
+                        qids,
+                        {},
+                        clarify_future,
+                    )
+                    await ws.send_str(
+                        gateway_event(
+                            "clarify.request",
+                            session_id,
+                            {
+                                "request_id": clarify_request_id,
+                                "questions": [
+                                    {
+                                        "qid": "q1",
+                                        "question": (
+                                            "Which mobile interface should "
+                                            "Hermes use?"
+                                        ),
+                                        "choices": [
+                                            "Compact",
+                                            "Balanced",
+                                            "Detailed",
+                                        ],
+                                        "multi_select": False,
+                                    },
+                                    {
+                                        "qid": "q2",
+                                        "question": (
+                                            "Which features matter most?"
+                                        ),
+                                        "choices": [
+                                            "Voice",
+                                            "Notifications",
+                                            "Dashboards",
+                                        ],
+                                        "multi_select": True,
+                                    },
+                                ],
+                            },
+                        )
+                    )
+                    answer = await clarify_future
+                    response_text = (
+                        f"Synthetic batch clarification received: {answer}."
+                        if answer
+                        else "Synthetic batch clarification was skipped."
+                    )
                 elif "clarify" in text.lower() and "test" in text.lower():
                     clarify_request_id = state.next_prompt_id("clarify")
                     clarify_future = asyncio.get_running_loop().create_future()
@@ -1237,6 +1294,10 @@ async def handle_rpc(
                     )
                 if clarify_request_id is not None:
                     pending_clarifications.pop(clarify_request_id, None)
+                    pending_batch_clarifications.pop(
+                        clarify_request_id,
+                        None,
+                    )
 
         previous = active_prompts.get(session_id)
         if previous is not None and not previous.done():
@@ -1298,7 +1359,65 @@ async def handle_rpc(
 
     if method == "clarify.respond":
         clarify_request_id = str(params.get("request_id") or "")
+        question_id = str(params.get("question_id") or "")
         answer = str(params.get("answer") or "")
+        batch = pending_batch_clarifications.get(clarify_request_id)
+        if batch is not None:
+            _, qids, answers, clarify_future = batch
+            if question_id:
+                if question_id not in qids:
+                    state.log(
+                        {
+                            **log_record,
+                            "request_id": clarify_request_id,
+                            "question_id": question_id,
+                            "status": "unknown_question",
+                        }
+                    )
+                    await ws.send_str(
+                        rpc_result(
+                            request_id,
+                            {"status": "unknown_question_id"},
+                        )
+                    )
+                    return
+                answers[question_id] = answer
+                remaining = [qid for qid in qids if qid not in answers]
+                if not clarify_future.done() and not remaining:
+                    clarify_future.set_result(
+                        "; ".join(answers[qid] for qid in qids)
+                    )
+                state.log(
+                    {
+                        **log_record,
+                        "request_id": clarify_request_id,
+                        "question_id": question_id,
+                        "answer_length": len(answer),
+                        "skipped": not bool(answer),
+                        "remaining": remaining,
+                        "status": "ok",
+                    }
+                )
+                await ws.send_str(
+                    rpc_result(
+                        request_id,
+                        {"status": "ok", "remaining": remaining},
+                    )
+                )
+                return
+            # No question_id on a batch request is a cancel-all, mirroring
+            # the gateway's plain-cancel path.
+            if not clarify_future.done():
+                clarify_future.set_result("")
+            state.log(
+                {
+                    **log_record,
+                    "request_id": clarify_request_id,
+                    "status": "cancelled",
+                }
+            )
+            await ws.send_str(rpc_result(request_id, {"status": "ok"}))
+            return
         entry = pending_clarifications.get(clarify_request_id)
         if entry is None:
             state.log(
@@ -1376,6 +1495,9 @@ async def websocket_gateway(request: web.Request) -> web.StreamResponse:
         str, tuple[str, str, asyncio.Future[str]]
     ] = {}
     pending_clarifications: dict[str, tuple[str, asyncio.Future[str]]] = {}
+    pending_batch_clarifications: dict[
+        str, tuple[str, list[str], dict[str, str], asyncio.Future[str]]
+    ] = {}
     await ws.send_json(state.turn_recovery.ready_frame())
     async for message in ws:
         if message.type == WSMsgType.TEXT:
@@ -1402,6 +1524,7 @@ async def websocket_gateway(request: web.Request) -> web.StreamResponse:
                 pending_approvals,
                 pending_sensitive_prompts,
                 pending_clarifications,
+                pending_batch_clarifications,
             )
         elif message.type == WSMsgType.ERROR:
             break

--- a/tools/fake_gateway/test_fake_gateway.py
+++ b/tools/fake_gateway/test_fake_gateway.py
@@ -1123,6 +1123,66 @@ async def probe(base_url: str) -> None:
                     skipped_turn_end = True
             assert "clarification was skipped" in skipped_delta
 
+            batch_prompt = await rpc(
+                ws,
+                121,
+                "prompt.submit",
+                {
+                    "session_id": session_id,
+                    "text": "batch clarify test",
+                },
+            )
+            assert batch_prompt["accepted"] is True
+            batch_message = await ws.receive(timeout=5)
+            batch_payload = json.loads(batch_message.data)
+            assert batch_payload["params"]["type"] == "clarify.request"
+            batch_request = batch_payload["params"]["payload"]
+            assert batch_request["questions"][0]["qid"] == "q1"
+            assert batch_request["questions"][1]["qid"] == "q2"
+            assert "question" not in batch_request
+
+            q1_result = await rpc(
+                ws,
+                122,
+                "clarify.respond",
+                {
+                    "request_id": batch_request["request_id"],
+                    "question_id": "q1",
+                    "answer": "Balanced",
+                },
+            )
+            assert q1_result["status"] == "ok"
+            assert q1_result["remaining"] == ["q2"]
+
+            q2_result = await rpc(
+                ws,
+                123,
+                "clarify.respond",
+                {
+                    "request_id": batch_request["request_id"],
+                    "question_id": "q2",
+                    "answer": "Voice, Notifications",
+                },
+            )
+            assert q2_result["status"] == "ok"
+            assert q2_result["remaining"] == []
+
+            batch_delta = ""
+            batch_turn_end = False
+            while not batch_turn_end:
+                message = await ws.receive(timeout=5)
+                assert message.type == WSMsgType.TEXT, message
+                payload = json.loads(message.data)
+                if payload.get("method") != "event":
+                    continue
+                params = payload["params"]
+                if params["type"] == "message.delta":
+                    batch_delta += params["payload"]["text"]
+                if params["type"] == "turn.end":
+                    batch_turn_end = True
+            assert "batch clarification received: Balanced" in batch_delta
+            assert "Voice, Notifications" in batch_delta
+
             late_clarify = await rpc(
                 ws,
                 21,


### PR DESCRIPTION
Fixes #94.

Stock Hermes gateways emit `clarify.request` with a batch `questions[]` array (even for a single prompt). The client only parsed the legacy flat shape, so the dialog opened with fallback text and no choices.

## Changes

- `GatewayClarifyRequest.fromEventDataList` expands batch payloads into per-question prompts carrying their `qid`; flat payloads still parse via `fromEventData`
- `clarify.respond` now echoes `question_id` back so the gateway locks each answer independently; per-question Skip no longer cancels the whole batch
- Prompt queue de-duplication keys on `request_id` + `question_id`
- Fake gateway mirrors the stock batch shape with a `batch clarify test` fixture and per-question lock handling; contract probe covers the round trip

## Verification

- `flutter analyze`: clean
- `flutter test`: 947/947 passing (12 clarify tests, 84 connection manager tests)
- Fake gateway contract probe (`test_fake_gateway.py`): passes, including the new batch clarify section