### PR TITLE
fix(android): list and apply chat models without a Desktop Gateway

### DIFF
--- a/lib/core/screens/chat_screen.dart
+++ b/lib/core/screens/chat_screen.dart
@@ -1283,24 +1283,30 @@ class _ChatScreenState extends State<ChatScreen> with WidgetsBindingObserver {
     }
   }
 
+  /// Dashboard client used to list models when no Desktop Gateway is
+  /// configured. Listing needs only `api/model/info` + `api/model/options`
+  /// over REST — the gateway WebSocket is required solely to push a
+  /// per-session override, which [_setSessionModel] skips when no gateway is
+  /// present (the chosen model rides on the chat request instead).
+  DashboardClient _modelListingClient() => DashboardClient(
+    host: widget.connection.host,
+    port: widget.connection.dashboardPort,
+    pathPrefix: widget.connection.dashboardPrefix ?? '',
+    proxied: widget.connection.dashboardProxied,
+    useHttps: widget.connection.useHttps,
+    username: widget.connection.dashboardUsername,
+    password: widget.connection.dashboardPassword,
+  );
+
   Future<void> _showModelSelector() async {
     final desktopGateway = _desktopGateway;
-    if (desktopGateway == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text(
-            'Configure Dashboard credentials to choose a chat model.',
-          ),
-        ),
-      );
-      return;
-    }
+    final restClient = desktopGateway == null ? _modelListingClient() : null;
 
     setState(() => _loadingModelOptions = true);
     try {
       final results = await Future.wait([
-        desktopGateway.getModelInfo(),
-        desktopGateway.getModelOptions(),
+        desktopGateway?.getModelInfo() ?? restClient!.getModelInfo(),
+        desktopGateway?.getModelOptions() ?? restClient!.getModelOptions(),
       ]);
       if (!mounted) return;
       final modelInfo = results[0];
@@ -1315,9 +1321,11 @@ class _ChatScreenState extends State<ChatScreen> with WidgetsBindingObserver {
           _sessionReasoningEffort ??
           WsClient.normalizeReasoningEffort(modelInfo['reasoning_effort']);
       try {
-        currentEffort = await desktopGateway.getSessionReasoning(
-          widget.session.id,
-        );
+        if (desktopGateway != null) {
+          currentEffort = await desktopGateway.getSessionReasoning(
+            widget.session.id,
+          );
+        }
       } catch (_) {
         // Older gateways may not expose session-scoped config.get. The model
         // selector remains usable with the profile/default effort.
@@ -1476,19 +1484,25 @@ class _ChatScreenState extends State<ChatScreen> with WidgetsBindingObserver {
 
   Future<void> _setSessionModel(_ModelSelection selection) async {
     final desktopGateway = _desktopGateway;
-    if (desktopGateway == null || _changingModel) return;
+    if (_changingModel) return;
     final choice = selection.choice;
     setState(() => _changingModel = true);
     try {
-      await desktopGateway.setSessionModel(
-        sessionId: widget.session.id,
-        provider: choice.provider,
-        model: choice.model,
-      );
-      await desktopGateway.setSessionReasoning(
-        sessionId: widget.session.id,
-        effort: selection.reasoningEffort,
-      );
+      // Without a gateway there is no session-scoped RPC to push the override
+      // to, so the selection stays local and is sent as the `model` field on
+      // each chat request instead. Reasoning effort is gateway-only and is
+      // simply not applied in that mode.
+      if (desktopGateway != null) {
+        await desktopGateway.setSessionModel(
+          sessionId: widget.session.id,
+          provider: choice.provider,
+          model: choice.model,
+        );
+        await desktopGateway.setSessionReasoning(
+          sessionId: widget.session.id,
+          effort: selection.reasoningEffort,
+        );
+      }
       final store = await _chatModelStore;
       await store.save(
         connectionIdentity: _chatModelConnectionIdentity,
@@ -1611,6 +1625,10 @@ class _ChatScreenState extends State<ChatScreen> with WidgetsBindingObserver {
     await _gateway.sendMessageStreaming(
       message: text,
       sessionId: widget.session.id,
+      // Carry the per-chat override on the request. The API server resolves
+      // `model` per call, so this reproduces session-scoped model selection
+      // without needing the gateway WebSocket to hold session state.
+      model: _sessionModelOverride ? _sessionModel : null,
       history: history,
       imageDataUrl: imageDataUrl,
       onToken: (token) {


### PR DESCRIPTION
The per-chat model picker is coupled to the Desktop Gateway WebSocket: `_showModelSelector` returns early unless a gateway client exists, and applying a choice pushes it over that socket via `setSessionModel` / `setSessionReasoning`. Any deployment without a reachable gateway therefore has a permanently dead picker, even though chat, sessions and history all work.

Listing needs only `api/model/info` and `api/model/options` over dashboard REST, and the API server already resolves a per-request `model` field, so the socket is not reqd for either half of the feature.

- list models through `DashboardClient` when no gateway is configured;
- keep the selection local and persisted instead of pushing it over the socket;
- carry the chosen model as the `model` field on the chat request, which `sendMessageStreaming` already accepts.

Reasoning effort remains gateway-only and is simply not applied in this mode.

Gateway turn recovery and its journal invariants are untouched: with a gateway configured every path behaves as before.

Motivation: we run Hermes headless and reverse-proxy only a handful of read-only dashboard GETs to the android client -- api/model/{info,options} for this picker, plus api/{memory,skills,cron/jobs} for the read-only tabs -- while deliberately not routing api/config, which returns provider keys and passwords. Every one of those tabs already works over REST; the model picker was the only feature that reached for the gateway socket, and only to read two endpoints we already publish.