### PR TITLE
fix: send the Hermes profile on the Desktop Gateway socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Release notes for
 versions prior to 1.0.7 are in the **What's new** sections of the [README](README.md).
 
+## [Unreleased]
+
+### Fixed
+
+- Chats over the Desktop Gateway transport could silently run under the
+  server's *default* profile instead of the profile the connection was meant
+  for. A machine-level `hermes dashboard`/`hermes serve` hosts every profile
+  and only runs a chat as a given profile when the `/api/ws` socket carries a
+  `profile` query parameter, which the app never sent. Connections now have an
+  optional **Hermes profile** field (under *Custom proxy and dashboard
+  details*) that is passed on the socket. Leave it blank for isolated
+  per-profile dashboards.
+
 ## [2.1.1] - 2026-09-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@ versions prior to 1.0.7 are in the **What's new** sections of the [README](READM
 - Chats over the Desktop Gateway transport could silently run under the
   server's *default* profile instead of the profile the connection was meant
   for. A machine-level `hermes dashboard`/`hermes serve` hosts every profile
-  and only runs a chat as a given profile when the `/api/ws` socket carries a
-  `profile` query parameter, which the app never sent. Connections now have an
-  optional **Hermes profile** field (under *Custom proxy and dashboard
-  details*) that is passed on the socket. Leave it blank for isolated
-  per-profile dashboards.
+  and scopes each `/api/ws` JSON-RPC call by a `profile` field in its params
+  (`session.create` / `session.resume` store it on the session), which the app
+  never sent. Connections now have an optional **Hermes profile** field (under
+  *Custom proxy and dashboard details*) that is added to every JSON-RPC
+  payload on that socket, the way Hermes Desktop does. Leave it blank for
+  isolated per-profile dashboards.
 
 ## [2.1.1] - 2026-09-06
 

--- a/README.md
+++ b/README.md
@@ -285,8 +285,8 @@ afterwards:
      both blank for an open (`--insecure`) dashboard.
    - **Hermes profile** — only when the dashboard is a *machine-level* one
      (`hermes dashboard` / `hermes serve` without `--isolated`) that hosts
-     several profiles. Hermes runs a chat on that socket as the profile named
-     in the `profile` query parameter, and falls back to its own default
+     several profiles. Hermes scopes each JSON-RPC call on that socket by a
+     `profile` field in the request, and falls back to its own default
      profile when it is missing, so without this field chats can quietly land
      in the wrong profile. Use the profile name exactly as in `hermes profile
      list`, e.g. `sol`. Leave blank for an isolated per-profile dashboard.

--- a/README.md
+++ b/README.md
@@ -283,6 +283,13 @@ afterwards:
      dashboard is exposed elsewhere.
    - **Username / Password** — only for a password-protected dashboard. Leave
      both blank for an open (`--insecure`) dashboard.
+   - **Hermes profile** — only when the dashboard is a *machine-level* one
+     (`hermes dashboard` / `hermes serve` without `--isolated`) that hosts
+     several profiles. Hermes runs a chat on that socket as the profile named
+     in the `profile` query parameter, and falls back to its own default
+     profile when it is missing, so without this field chats can quietly land
+     in the wrong profile. Use the profile name exactly as in `hermes profile
+     list`, e.g. `sol`. Leave blank for an isolated per-profile dashboard.
 3. Tap **Save**. The app validates the settings against the dashboard before
    storing them.
 

--- a/lib/core/models/connection.dart
+++ b/lib/core/models/connection.dart
@@ -42,11 +42,12 @@ class SavedConnection {
   /// Optional Hermes profile name for the Desktop gateway transport.
   ///
   /// A machine-level `hermes dashboard` / `hermes serve` hosts every profile
-  /// on the machine and runs a chat under the profile named by the `profile`
-  /// query parameter on `/api/ws`; without it the chat silently runs as the
-  /// server's own (default) profile. Set this to the profile this connection
-  /// is meant to talk to (e.g. `sol`). Leave null for an isolated per-profile
-  /// dashboard, where the server already knows its profile.
+  /// on the machine and scopes each `/api/ws` JSON-RPC call by the `profile`
+  /// field in its params (`session.create` / `session.resume` store it on the
+  /// session); without it the chat silently runs as the server's own
+  /// (default) profile. Set this to the profile this connection is meant to
+  /// talk to (e.g. `sol`). Leave null for an isolated per-profile dashboard,
+  /// where the server already knows its profile.
   final String? gatewayProfile;
 
   SavedConnection({

--- a/lib/core/models/connection.dart
+++ b/lib/core/models/connection.dart
@@ -39,6 +39,16 @@ class SavedConnection {
   final String? dashboardUsername;
   final String? dashboardPassword;
 
+  /// Optional Hermes profile name for the Desktop gateway transport.
+  ///
+  /// A machine-level `hermes dashboard` / `hermes serve` hosts every profile
+  /// on the machine and runs a chat under the profile named by the `profile`
+  /// query parameter on `/api/ws`; without it the chat silently runs as the
+  /// server's own (default) profile. Set this to the profile this connection
+  /// is meant to talk to (e.g. `sol`). Leave null for an isolated per-profile
+  /// dashboard, where the server already knows its profile.
+  final String? gatewayProfile;
+
   SavedConnection({
     required this.id,
     required this.label,
@@ -53,6 +63,7 @@ class SavedConnection {
     this.dashboardPortOverride,
     this.dashboardUsername,
     this.dashboardPassword,
+    this.gatewayProfile,
   });
 
   String get baseUrl {
@@ -155,6 +166,9 @@ class SavedConnection {
     if (dashboardUsername != null && dashboardUsername!.isNotEmpty) {
       m['dashboard_username'] = dashboardUsername;
     }
+    if (gatewayProfile != null && gatewayProfile!.isNotEmpty) {
+      m['gateway_profile'] = gatewayProfile;
+    }
     return m;
   }
 
@@ -180,6 +194,7 @@ class SavedConnection {
       dashboardPortOverride: map['dashboard_port'] as int?,
       dashboardUsername: nonEmpty(map['dashboard_username']),
       dashboardPassword: nonEmpty(map['dashboard_password']),
+      gatewayProfile: nonEmpty(map['gateway_profile']),
     );
   }
 
@@ -199,12 +214,14 @@ class SavedConnection {
     int? dashboardPortOverride,
     String? dashboardUsername,
     String? dashboardPassword,
+    String? gatewayProfile,
     bool clearGatewayPrefix = false,
     bool clearDashboardPrefix = false,
     bool clearDashboardPort = false,
     bool clearDashboardUsername = false,
     bool clearDashboardPassword = false,
     bool clearDesktopGatewayUrl = false,
+    bool clearGatewayProfile = false,
   }) {
     return SavedConnection(
       id: id,
@@ -232,6 +249,9 @@ class SavedConnection {
       dashboardPassword: clearDashboardPassword
           ? null
           : (dashboardPassword ?? this.dashboardPassword),
+      gatewayProfile: clearGatewayProfile
+          ? null
+          : (gatewayProfile ?? this.gatewayProfile),
     );
   }
 }

--- a/lib/core/services/config_backup.dart
+++ b/lib/core/services/config_backup.dart
@@ -110,6 +110,7 @@ class ConfigBackup {
       'dashboard_port': connection.dashboardPortOverride,
       'dashboard_username': connection.dashboardUsername,
       'dashboard_password': connection.dashboardPassword,
+      'gateway_profile': connection.gatewayProfile,
     };
   }
 
@@ -133,6 +134,7 @@ class ConfigBackup {
       dashboardPortOverride: map['dashboard_port'] as int?,
       dashboardUsername: nonEmpty(map['dashboard_username']),
       dashboardPassword: nonEmpty(map['dashboard_password']),
+      gatewayProfile: nonEmpty(map['gateway_profile']),
     );
   }
 

--- a/lib/core/services/connection_manager.dart
+++ b/lib/core/services/connection_manager.dart
@@ -284,8 +284,10 @@ class ConnectionManager {
     int? dashboardPort,
     String? dashboardUsername,
     String? dashboardPassword,
+    String? gatewayProfile,
   }) async {
     final normalized = SavedConnection.normalizeHostAndPort(host, port);
+    final profile = gatewayProfile?.trim();
     final conn = SavedConnection(
       id: _uuid.v4(),
       label: label,
@@ -300,6 +302,7 @@ class ConnectionManager {
       dashboardPortOverride: dashboardPort,
       dashboardUsername: dashboardUsername,
       dashboardPassword: dashboardPassword,
+      gatewayProfile: profile == null || profile.isEmpty ? null : profile,
     );
     final current = getConnections();
     current.insert(0, conn);
@@ -329,6 +332,7 @@ class ConnectionManager {
     int? dashboardPort,
     String? dashboardUsername,
     String? dashboardPassword,
+    String? gatewayProfile,
   }) async {
     final current = getConnections();
     final idx = current.indexWhere((c) => c.id == connId);
@@ -344,6 +348,7 @@ class ConnectionManager {
     final dashUser = dashboardUsername?.trim();
     final dashPass = dashboardPassword?.trim();
     final desktopGateway = desktopGatewayUrl?.trim();
+    final profile = gatewayProfile?.trim();
 
     current[idx] = current[idx].copyWith(
       label: label,
@@ -368,6 +373,8 @@ class ConnectionManager {
       clearDashboardUsername: dashUser != null && dashUser.isEmpty,
       dashboardPassword: dashPass == null || dashPass.isEmpty ? null : dashPass,
       clearDashboardPassword: dashPass != null && dashPass.isEmpty,
+      gatewayProfile: profile == null || profile.isEmpty ? null : profile,
+      clearGatewayProfile: profile != null && profile.isEmpty,
     );
     await _commitCredentialAndMetadata(
       connectionId: connId,

--- a/lib/core/services/desktop_gateway_client.dart
+++ b/lib/core/services/desktop_gateway_client.dart
@@ -32,6 +32,10 @@ class DesktopGatewayClient {
   final String _baseUrl;
   final DashboardClient _dashboard;
   final String _documentProfile;
+
+  /// Hermes profile the gateway socket should run chats under, or null to
+  /// let the server use its own. See [SavedConnection.gatewayProfile].
+  final String? _gatewayProfile;
   WsClient? _ws;
   final Map<String, String> _gatewaySessionIds = {};
   DesktopAsyncEventCallback? _asyncEventListener;
@@ -58,6 +62,7 @@ class DesktopGatewayClient {
     required this._baseUrl,
     required this._dashboard,
     required this._documentProfile,
+    this._gatewayProfile,
   });
 
   /// The canonical gateway origin for [connection].
@@ -145,6 +150,7 @@ class DesktopGatewayClient {
         password: connection.dashboardPassword,
       ),
       documentProfile: documentIntakeProfileForConnection(connection),
+      gatewayProfile: connection.gatewayProfile,
     );
   }
 
@@ -168,7 +174,7 @@ class DesktopGatewayClient {
     existing?.close();
     _gatewaySessionIds.clear();
     final ticket = await _dashboard.mintWebSocketTicket();
-    final client = WsClient(_baseUrl, ticket: ticket);
+    final client = WsClient(_baseUrl, ticket: ticket, profile: _gatewayProfile);
     _installAsyncEventBridge(client);
     client.onConnectionChanged = (connected) {
       if (connected) {
@@ -247,7 +253,7 @@ class DesktopGatewayClient {
     existing?.close();
     _gatewaySessionIds.clear();
     final ticket = await _dashboard.mintWebSocketTicket();
-    final client = WsClient(_baseUrl, ticket: ticket);
+    final client = WsClient(_baseUrl, ticket: ticket, profile: _gatewayProfile);
     _installAsyncEventBridge(client);
     client.onConnectionChanged = (connected) {
       if (connected) {
@@ -280,7 +286,7 @@ class DesktopGatewayClient {
       journal: journal ?? GatewayTurnJournal(),
       freshSocketFactory: () async {
         final ticket = await _dashboard.mintWebSocketTicket();
-        return WsClient(_baseUrl, ticket: ticket);
+        return WsClient(_baseUrl, ticket: ticket, profile: _gatewayProfile);
       },
     );
   }

--- a/lib/core/services/ws_client.dart
+++ b/lib/core/services/ws_client.dart
@@ -153,6 +153,7 @@ class WsClient {
   final String baseUrl;
   final String? _token;
   final String? _ticket;
+  final String? _profile;
   IOWebSocketChannel? _channel;
   bool _connected = false;
   int _nextId = 1;
@@ -180,11 +181,16 @@ class WsClient {
   ConnectionCallback? onConnectionChanged;
   GatewayReadyCallback? onGatewayReady;
 
-  factory WsClient(String baseUrl, {String? token, String? ticket}) {
-    return WsClient._(baseUrl, token, ticket);
+  factory WsClient(
+    String baseUrl, {
+    String? token,
+    String? ticket,
+    String? profile,
+  }) {
+    return WsClient._(baseUrl, token, ticket, profile);
   }
 
-  WsClient._(this.baseUrl, this._token, this._ticket);
+  WsClient._(this.baseUrl, this._token, this._ticket, this._profile);
 
   /// Connect to the WebSocket gateway.
   Future<void> connect() async {
@@ -201,7 +207,12 @@ class WsClient {
     // A transport can close before a caller starts waiting for gateway.ready.
     // Observe that error future immediately; the waiter still receives it.
     readyCompleter.future.ignore();
-    final wsUrl = buildWebSocketUrl(baseUrl, token: _token, ticket: _ticket);
+    final wsUrl = buildWebSocketUrl(
+      baseUrl,
+      token: _token,
+      ticket: _ticket,
+      profile: _profile,
+    );
     final channel = IOWebSocketChannel.connect(Uri.parse(wsUrl));
     _channel = channel;
     channel.stream.listen(
@@ -314,21 +325,31 @@ class WsClient {
 
   /// Produces the gateway `/api/ws` URL. Secured Desktop gateways use a
   /// single-use ticket; insecure legacy gateways still use a session token.
+  ///
+  /// [profile] selects which Hermes profile the socket's chat runs under on a
+  /// machine-level (multi-profile) dashboard. Hermes reads it from the
+  /// `profile` query parameter; when it is absent the server falls back to its
+  /// own profile, so a blank value is deliberately not sent.
   static String buildWebSocketUrl(
     String baseUrl, {
     String? token,
     String? ticket,
+    String? profile,
   }) {
     final socketBase = baseUrl
         .replaceFirst('http://', 'ws://')
         .replaceFirst('https://', 'wss://');
     final uri = Uri.parse('$socketBase/api/ws');
-    final credential = ticket?.trim().isNotEmpty == true
-        ? {'ticket': ticket!.trim()}
-        : token?.trim().isNotEmpty == true
-        ? {'token': token!.trim()}
-        : const <String, String>{};
-    return uri.replace(queryParameters: credential).toString();
+    final query = <String, String>{};
+    if (ticket?.trim().isNotEmpty == true) {
+      query['ticket'] = ticket!.trim();
+    } else if (token?.trim().isNotEmpty == true) {
+      query['token'] = token!.trim();
+    }
+    if (profile?.trim().isNotEmpty == true) {
+      query['profile'] = profile!.trim();
+    }
+    return uri.replace(queryParameters: query).toString();
   }
 
   /// Handle inbound messages.
@@ -758,10 +779,7 @@ class WsClient {
         'A Hermes request ID is required',
       );
     }
-    final params = <String, dynamic>{
-      'request_id': requestId,
-      'answer': answer,
-    };
+    final params = <String, dynamic>{'request_id': requestId, 'answer': answer};
     if (questionId != null && questionId.trim().isNotEmpty) {
       params['question_id'] = questionId;
     }

--- a/lib/core/services/ws_client.dart
+++ b/lib/core/services/ws_client.dart
@@ -207,12 +207,7 @@ class WsClient {
     // A transport can close before a caller starts waiting for gateway.ready.
     // Observe that error future immediately; the waiter still receives it.
     readyCompleter.future.ignore();
-    final wsUrl = buildWebSocketUrl(
-      baseUrl,
-      token: _token,
-      ticket: _ticket,
-      profile: _profile,
-    );
+    final wsUrl = buildWebSocketUrl(baseUrl, token: _token, ticket: _ticket);
     final channel = IOWebSocketChannel.connect(Uri.parse(wsUrl));
     _channel = channel;
     channel.stream.listen(
@@ -325,31 +320,40 @@ class WsClient {
 
   /// Produces the gateway `/api/ws` URL. Secured Desktop gateways use a
   /// single-use ticket; insecure legacy gateways still use a session token.
-  ///
-  /// [profile] selects which Hermes profile the socket's chat runs under on a
-  /// machine-level (multi-profile) dashboard. Hermes reads it from the
-  /// `profile` query parameter; when it is absent the server falls back to its
-  /// own profile, so a blank value is deliberately not sent.
   static String buildWebSocketUrl(
     String baseUrl, {
     String? token,
     String? ticket,
-    String? profile,
   }) {
     final socketBase = baseUrl
         .replaceFirst('http://', 'ws://')
         .replaceFirst('https://', 'wss://');
     final uri = Uri.parse('$socketBase/api/ws');
-    final query = <String, String>{};
-    if (ticket?.trim().isNotEmpty == true) {
-      query['ticket'] = ticket!.trim();
-    } else if (token?.trim().isNotEmpty == true) {
-      query['token'] = token!.trim();
-    }
-    if (profile?.trim().isNotEmpty == true) {
-      query['profile'] = profile!.trim();
-    }
-    return uri.replace(queryParameters: query).toString();
+    final credential = ticket?.trim().isNotEmpty == true
+        ? {'ticket': ticket!.trim()}
+        : token?.trim().isNotEmpty == true
+        ? {'token': token!.trim()}
+        : const <String, String>{};
+    return uri.replace(queryParameters: credential).toString();
+  }
+
+  /// Adds the connection's Hermes profile to a JSON-RPC params map.
+  ///
+  /// A machine-level `hermes dashboard` / `hermes serve` hosts every profile
+  /// on the machine and scopes each RPC by `params['profile']`
+  /// (`_profile_db` / `_profile_scoped` on the server; `session.create` and
+  /// `session.resume` store it on the session so later turns re-bind to that
+  /// profile's home). The socket URL carries no profile. Hermes Desktop sends
+  /// the field on every scoped request, so this does the same. A blank
+  /// profile sends nothing and the server keeps its own default; a caller that
+  /// already set `profile` wins.
+  static Map<String, dynamic> withProfile(
+    Map<String, dynamic> params,
+    String? profile,
+  ) {
+    final name = profile?.trim() ?? '';
+    if (name.isEmpty || params.containsKey('profile')) return params;
+    return <String, dynamic>{...params, 'profile': name};
   }
 
   /// Handle inbound messages.
@@ -577,7 +581,7 @@ class WsClient {
       jsonEncode({
         'jsonrpc': '2.0',
         'method': method,
-        'params': params,
+        'params': withProfile(params, _profile),
         'id': id,
       }),
     );
@@ -614,7 +618,7 @@ class WsClient {
       jsonEncode({
         'jsonrpc': '2.0',
         'method': method,
-        'params': params,
+        'params': withProfile(params, _profile),
         'id': id,
       }),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -381,6 +381,7 @@ class HomeScreenState extends State<HomeScreen> {
               dashboardPort,
               dashboardUsername,
               dashboardPassword,
+              gatewayProfile,
             }) async {
               if (existing == null) {
                 await widget.connManager.saveConnection(
@@ -395,6 +396,7 @@ class HomeScreenState extends State<HomeScreen> {
                   dashboardPort: dashboardPort,
                   dashboardUsername: dashboardUsername,
                   dashboardPassword: dashboardPassword,
+                  gatewayProfile: gatewayProfile,
                 );
               } else {
                 await widget.connManager.updateConnection(
@@ -410,6 +412,7 @@ class HomeScreenState extends State<HomeScreen> {
                   dashboardPort: dashboardPort,
                   dashboardUsername: dashboardUsername,
                   dashboardPassword: dashboardPassword,
+                  gatewayProfile: gatewayProfile,
                 );
               }
               _refresh();
@@ -938,6 +941,7 @@ class _AddDialog extends StatefulWidget {
     int? dashboardPort,
     String? dashboardUsername,
     String? dashboardPassword,
+    String? gatewayProfile,
   })
   onSave;
   const _AddDialog({required this.onSave, this.initialConnection});
@@ -957,6 +961,7 @@ class _AddDialogState extends State<_AddDialog> {
   late final TextEditingController _dashUser;
   late final TextEditingController _dashPass;
   late final TextEditingController _desktopGatewayUrl;
+  late final TextEditingController _gatewayProfile;
   late bool _showDashboard;
   late bool _dashboardProxied;
   bool _validating = false;
@@ -993,9 +998,11 @@ class _AddDialogState extends State<_AddDialog> {
     _desktopGatewayUrl = TextEditingController(
       text: conn?.desktopGatewayUrl ?? '',
     );
+    _gatewayProfile = TextEditingController(text: conn?.gatewayProfile ?? '');
     _dashboardProxied = conn?.dashboardProxied ?? false;
     _showDashboard =
         conn?.gatewayPrefix?.isNotEmpty == true ||
+        conn?.gatewayProfile?.isNotEmpty == true ||
         conn?.dashboardPrefix?.isNotEmpty == true ||
         conn?.dashboardPortOverride != null ||
         conn?.dashboardUsername?.isNotEmpty == true ||
@@ -1051,6 +1058,18 @@ class _AddDialogState extends State<_AddDialog> {
       final dashUser = _dashUser.text.trim();
       final dashPass = _dashPass.text.trim();
       final desktopGatewayUrl = _desktopGatewayUrl.text.trim();
+      final gatewayProfile = _gatewayProfile.text.trim();
+      if (gatewayProfile.contains('/') ||
+          gatewayProfile.contains(RegExp(r'\s'))) {
+        setState(() {
+          _error =
+              'Hermes profile must be a plain profile name such as "sol", '
+              'not a path.';
+          _validating = false;
+          _showDashboard = true;
+        });
+        return;
+      }
       final dashPort = dashPortText.isEmpty ? null : int.tryParse(dashPortText);
 
       // If the user supplied any dashboard details, validate them before saving
@@ -1108,6 +1127,7 @@ class _AddDialogState extends State<_AddDialog> {
         dashboardPort: dashPort,
         dashboardUsername: dashUser.isEmpty ? null : dashUser,
         dashboardPassword: dashPass.isEmpty ? null : dashPass,
+        gatewayProfile: gatewayProfile.isEmpty ? null : gatewayProfile,
       );
       if (mounted) Navigator.pop(context);
     } on CredentialStorageException {
@@ -1293,6 +1313,20 @@ class _AddDialogState extends State<_AddDialog> {
                 keyboardType: TextInputType.url,
                 autocorrect: false,
               ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _gatewayProfile,
+                decoration: const InputDecoration(
+                  labelText: 'Hermes profile (optional)',
+                  hintText: 'e.g. sol',
+                  helperText:
+                      'Profile this connection chats as when the dashboard '
+                      'serves several profiles. Leave blank for an isolated '
+                      'per-profile dashboard.',
+                  helperMaxLines: 3,
+                ),
+                autocorrect: false,
+              ),
             ],
           ],
         ),
@@ -1331,6 +1365,7 @@ class _AddDialogState extends State<_AddDialog> {
     _dashUser.dispose();
     _dashPass.dispose();
     _desktopGatewayUrl.dispose();
+    _gatewayProfile.dispose();
     super.dispose();
   }
 }

--- a/test/config_backup_test.dart
+++ b/test/config_backup_test.dart
@@ -23,6 +23,7 @@ void main() {
           dashboardPortOverride: 9119,
           dashboardUsername: 'carlos',
           dashboardPassword: 'dash-secret',
+          gatewayProfile: 'carlos-work',
         ),
       ],
       preferences: const <String, Object>{
@@ -51,6 +52,7 @@ void main() {
       expect(conn.dashboardUsername, 'carlos');
       expect(conn.dashboardPassword, 'dash-secret');
       expect(conn.dashboardPortOverride, 9119);
+      expect(conn.gatewayProfile, 'carlos-work');
     });
 
     test('round-trips preference values without losing their types', () {

--- a/test/connection_manager_test.dart
+++ b/test/connection_manager_test.dart
@@ -1228,30 +1228,81 @@ void main() {
       );
     });
 
-    test(
-      'names the Hermes profile so a multi-profile dashboard chats as it',
-      () {
-        expect(
-          WsClient.buildWebSocketUrl(
-            'https://hermes-desktop.example.lan',
-            ticket: 'ticket',
-            profile: 'sol',
-          ),
-          'wss://hermes-desktop.example.lan/api/ws?ticket=ticket&profile=sol',
-        );
-      },
-    );
-
-    test('omits a blank profile so the server keeps its own default', () {
+    test('withProfile adds the profile to params, blank sends nothing', () {
+      expect(WsClient.withProfile({'session_id': 'abc'}, 'sol'), {
+        'session_id': 'abc',
+        'profile': 'sol',
+      });
+      expect(WsClient.withProfile({'session_id': 'abc'}, '   '), {
+        'session_id': 'abc',
+      });
+      expect(WsClient.withProfile({'session_id': 'abc'}, null), {
+        'session_id': 'abc',
+      });
       expect(
-        WsClient.buildWebSocketUrl(
-          'http://hermes.local:9119',
-          token: 'spa',
-          profile: '   ',
-        ),
-        'ws://hermes.local:9119/api/ws?token=spa',
+        WsClient.withProfile({'session_id': 'abc', 'profile': 'kael'}, 'sol'),
+        {'session_id': 'abc', 'profile': 'kael'},
       );
     });
+
+    test(
+      'sends the Hermes profile in every JSON-RPC payload, not the URL',
+      () async {
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        final requestUris = <Uri>[];
+        final frames = <Map<String, dynamic>>[];
+        final socketSubscription = server.listen((request) async {
+          requestUris.add(request.uri);
+          final socket = await WebSocketTransformer.upgrade(request);
+          socket.listen((message) {
+            final frame = jsonDecode(message as String) as Map<String, dynamic>;
+            frames.add(frame);
+            socket.add(
+              jsonEncode({
+                'jsonrpc': '2.0',
+                'id': frame['id'],
+                'result': {'session_id': 'abc'},
+              }),
+            );
+          });
+        });
+        final client = WsClient(
+          'http://127.0.0.1:${server.port}',
+          token: 'spa',
+          profile: 'sol',
+        );
+        try {
+          await client.connect();
+          await client.resumeSession('abc');
+          await client.createOrResumeSession('abc');
+          await client.send('config.get', {'key': 'model'});
+
+          expect(requestUris, hasLength(1));
+          expect(requestUris.single.path, '/api/ws');
+          expect(requestUris.single.queryParameters, {'token': 'spa'});
+          expect(frames.map((f) => f['method']), [
+            'session.resume',
+            'session.create',
+            'config.get',
+          ]);
+          for (final frame in frames) {
+            expect(
+              (frame['params'] as Map<String, dynamic>)['profile'],
+              'sol',
+              reason: '${frame['method']} must carry the profile',
+            );
+          }
+          expect(frames.first['params'], {
+            'session_id': 'abc',
+            'profile': 'sol',
+          });
+        } finally {
+          client.close();
+          await socketSubscription.cancel();
+          await server.close(force: true);
+        }
+      },
+    );
 
     test(
       'pins an immutable gateway.ready received before its waiter',

--- a/test/connection_manager_test.dart
+++ b/test/connection_manager_test.dart
@@ -345,6 +345,32 @@ void main() {
       expect(restored.dashboardPort, 9119);
     });
 
+    test('round-trips the Hermes profile and clears it via copyWith', () {
+      final conn = SavedConnection(
+        id: '4',
+        label: 'Sol',
+        host: 'hermes.example.com',
+        port: 8642,
+        apiKey: 'key',
+        gatewayProfile: 'sol',
+      );
+      final restored = SavedConnection.fromMap(conn.toMap());
+      expect(conn.toMap()['gateway_profile'], 'sol');
+      expect(restored.gatewayProfile, 'sol');
+      expect(
+        SavedConnection.fromMap({
+          'id': '5',
+          'label': 'Blank',
+          'host': 'hermes.example.com',
+          'port': 8642,
+          'gateway_profile': '  ',
+        }).gatewayProfile,
+        isNull,
+      );
+      expect(conn.copyWith(label: 'Still Sol').gatewayProfile, 'sol');
+      expect(conn.copyWith(clearGatewayProfile: true).gatewayProfile, isNull);
+    });
+
     test('fromMap normalises blank credentials to null', () {
       final restored = SavedConnection.fromMap({
         'id': '3',
@@ -1198,6 +1224,31 @@ void main() {
     test('keeps legacy token support for insecure gateways', () {
       expect(
         WsClient.buildWebSocketUrl('http://hermes.local:9119', token: 'spa'),
+        'ws://hermes.local:9119/api/ws?token=spa',
+      );
+    });
+
+    test(
+      'names the Hermes profile so a multi-profile dashboard chats as it',
+      () {
+        expect(
+          WsClient.buildWebSocketUrl(
+            'https://hermes-desktop.example.lan',
+            ticket: 'ticket',
+            profile: 'sol',
+          ),
+          'wss://hermes-desktop.example.lan/api/ws?ticket=ticket&profile=sol',
+        );
+      },
+    );
+
+    test('omits a blank profile so the server keeps its own default', () {
+      expect(
+        WsClient.buildWebSocketUrl(
+          'http://hermes.local:9119',
+          token: 'spa',
+          profile: '   ',
+        ),
         'ws://hermes.local:9119/api/ws?token=spa',
       );
     });


### PR DESCRIPTION
## Problem

When a connection has dashboard credentials (or a Desktop Gateway URL), chat moves onto the Desktop Gateway transport (`/api/ws`). On a **machine-level** `hermes dashboard` / `hermes serve` — the default when you run it without `--isolated` — that server hosts every profile on the machine and scopes each JSON-RPC call by a `profile` field in its params (`tui_gateway/server.py` `_profile_db` / `_profile_scoped`; `session.create` and `session.resume` store it on the session so later turns re-bind to that profile's home). The app never sent that field, so every chat quietly ran as the server's own (default) profile.

Observed on Hermes v0.21.0 (2026.8.31) with app v2.1.1: a connection meant for profile `sol` (gateway prefix `/p/sol`, dashboard 9119 with basic auth) produced short, generic replies from the default profile's model; the turns landed in the root session store with `source: tui` and never appeared in `sol`'s sessions. The session list looked right because it comes from the Gateway API with the `/p/sol` prefix — only the chat socket was misrouted, which makes this easy to miss.

## Fix

- New optional per-connection field **Hermes profile** (`SavedConnection.gatewayProfile`, persisted as `gateway_profile`, included in config backup/restore) under *Custom proxy and dashboard details*.
- `WsClient` merges `profile` into the params of every JSON-RPC request it sends on that socket (`send` and `sendStreaming`), the same way Hermes Desktop attaches its active profile to every scoped request. A caller that already set `profile` wins; a blank field sends nothing so the server keeps its own default.
- `DesktopGatewayClient` passes the profile to the socket client on all three construction paths (initial connect, reconnect, recovery-coordinator fresh sockets).
- Light input validation (no `/` or whitespace) so a path prefix pasted by mistake is rejected with a clear message.
- README + CHANGELOG entry.

Backward compatible: connections without the field behave exactly as before; isolated per-profile dashboards need nothing. The socket URL is unchanged.

### Revision history

The first push put the profile in the `/api/ws` query string. That was wrong: the `?profile=` reader I had cited in 0.21.0 belongs to `/api/pty`, not `/api/ws`, and the chat socket never looks at the URL. Thanks to the automation review for catching it. The current revision sends the field in the payload as described above.

## Not in this PR

The dashboard REST screens (Memory / Cron / Skills) on a machine-level dashboard also read the server's own profile. Hermes' sessions router accepts `?profile=` but the cron/skills routers (in the build I tested) do not, so I left those untouched rather than half-fix them. Happy to follow up if you'd like the sessions search to carry the profile too.

## Testing

- `flutter analyze` clean, `dart format` clean, `flutter test` green (results in the comments).
- New tests: `withProfile` merge rules (add / blank / null / caller wins); a fake gateway on a loopback `HttpServer` asserting that `session.resume`, `session.create` and an arbitrary RPC each carry `profile` in their params while the upgrade request URL stays `/api/ws?token=…`; model round-trip + `copyWith(clearGatewayProfile: true)`; config-backup round-trip.
- Not exercised on a device from this branch (no Android build environment on the machine I used). The bug itself was reproduced on a device with v2.1.1 as described above; the server contract was verified against Hermes 0.21.0 and upstream `main` (`tui_gateway/server.py`, `tui_gateway/methods_session.py`, `apps/desktop/src/api/client.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
